### PR TITLE
Shallow object inherit merge

### DIFF
--- a/client/src/get/types.ts
+++ b/client/src/get/types.ts
@@ -6,6 +6,7 @@ export type Inherit =
       $type?: string | string[]
       $name?: string | string[]
       $item?: Id | Id[]
+      $merge: boolean
       $required?: Id | Id[]
     }
 

--- a/lua/src/get/getByType.ts
+++ b/lua/src/get/getByType.ts
@@ -329,12 +329,9 @@ const object = (
     }
 
     if (mergeProps && mergeProps.properties) {
-      logger.info('checking if finished shallow merging', mergeProps)
       for (const topLevelKey in mergeProps.properties) {
-        logger.info('checking key', topLevelKey)
         const fullPathToKey = field + '.' + topLevelKey
         if (!getNestedField(result, fullPathToKey)) {
-          logger.info('not found', topLevelKey)
           return false
         }
       }

--- a/lua/src/get/index.ts
+++ b/lua/src/get/index.ts
@@ -108,7 +108,6 @@ function getField(
           hasKeys = true
           const f = field && field.length > 0 ? field + '.' + key : key
           if (props[key] === true) {
-            // logger.info(`key: ${key} field ${f}`)
             if (
               !getByType(result, schema, id, f, language, version, includeMeta)
             ) {

--- a/lua/src/get/inherit.ts
+++ b/lua/src/get/inherit.ts
@@ -150,9 +150,9 @@ function setFromAncestors(
               merge
             )
           ) {
+            logger.info('done inheriting at', parent)
             return true
           }
-          logger.info('not done', id, field, result)
         }
       }
 

--- a/lua/src/get/inherit.ts
+++ b/lua/src/get/inherit.ts
@@ -50,6 +50,7 @@ function setFromAncestors(
   version?: string,
   includeMeta?: boolean,
   fieldFrom?: string | string[],
+  merge?: boolean,
   tryAncestorCondition?: (ancestor: Id) => boolean,
   acceptAncestorCondition?: (result: any) => boolean,
   ancestorsWithScores?: Id[],
@@ -128,9 +129,30 @@ function setFromAncestors(
             return true
           }
         } else {
-          if (getByType(result, schema, parent, field, language, version)) {
+          logger.info(
+            'inheriting result currently',
+            id,
+            parent,
+            field,
+            result,
+            'MERGING???',
+            merge
+          )
+          if (
+            getByType(
+              result,
+              schema,
+              parent,
+              field,
+              language,
+              version,
+              includeMeta,
+              merge
+            )
+          ) {
             return true
           }
+          logger.info('not done', id, field, result)
         }
       }
 
@@ -206,6 +228,7 @@ function inheritItem(
         version,
         includeMeta,
         '',
+        false,
         (ancestor: Id) => {
           for (const match of matches) {
             if (match === ancestor) {
@@ -270,7 +293,8 @@ export default function inherit(
         language,
         version,
         includeMeta,
-        fieldFrom
+        fieldFrom,
+        true
       )
     } else if (inherit.$type) {
       const types: string[] = ensureArray(inherit.$type)
@@ -284,6 +308,7 @@ export default function inherit(
         version,
         includeMeta,
         fieldFrom,
+        true,
         (ancestor: Id) => {
           for (const type of types) {
             if (type === getTypeFromId(ancestor)) {
@@ -306,6 +331,7 @@ export default function inherit(
         version,
         includeMeta,
         fieldFrom,
+        true,
         (ancestor: Id) => {
           for (const name of names) {
             if (name === getName(ancestor)) {

--- a/lua/src/get/inherit.ts
+++ b/lua/src/get/inherit.ts
@@ -129,15 +129,6 @@ function setFromAncestors(
             return true
           }
         } else {
-          logger.info(
-            'inheriting result currently',
-            id,
-            parent,
-            field,
-            result,
-            'MERGING???',
-            merge
-          )
           if (
             getByType(
               result,
@@ -150,7 +141,6 @@ function setFromAncestors(
               merge
             )
           ) {
-            logger.info('done inheriting at', parent)
             return true
           }
         }

--- a/lua/src/get/inherit.ts
+++ b/lua/src/get/inherit.ts
@@ -298,7 +298,7 @@ export default function inherit(
         version,
         includeMeta,
         fieldFrom,
-        true,
+        inherit.$merge !== undefined ? inherit.$merge : true,
         (ancestor: Id) => {
           for (const type of types) {
             if (type === getTypeFromId(ancestor)) {
@@ -321,7 +321,7 @@ export default function inherit(
         version,
         includeMeta,
         fieldFrom,
-        true,
+        inherit.$merge !== undefined ? inherit.$merge : true,
         (ancestor: Id) => {
           for (const name of names) {
             if (name === getName(ancestor)) {
@@ -346,6 +346,20 @@ export default function inherit(
         language,
         version,
         includeMeta
+      )
+    } else if (inherit.$merge !== undefined) {
+      // if only merge specified, same as inherit: true with merge off
+      return setFromAncestors(
+        getField,
+        result,
+        schema,
+        id,
+        field,
+        language,
+        version,
+        includeMeta,
+        fieldFrom,
+        inherit.$merge
       )
     }
 

--- a/lua/src/modify/delete.ts
+++ b/lua/src/modify/delete.ts
@@ -29,6 +29,14 @@ export function deleteItem(id: Id, hierarchy: boolean = true): boolean {
   r.del(id + '._depth')
   sendEvent(id, '', 'delete')
 
+  const vals = r.hgetall(id)
+  for (let i = 0; i < vals.length; i += 2) {
+    // found a set value, cleaning up the set key
+    if (vals[i + 1] === '___selva_$set') {
+      r.del(id + '.' + vals[i])
+    }
+  }
+
   // returns true if it existed
   return r.del(id) > 0
 }

--- a/lua/src/modify/index.ts
+++ b/lua/src/modify/index.ts
@@ -85,19 +85,20 @@ function setInternalArrayStructure(
 
   if (isArray(value)) {
     resetSet(id, field, value, update, hierarchy)
-    return
-  }
-
-  if (value.$value) {
+  } else if (value.$value) {
     resetSet(id, field, value, update, hierarchy)
-    return
+  } else {
+    if (value.$add) {
+      addToSet(id, field, value.$add, update, hierarchy)
+    }
+    if (value.$delete) {
+      removeFromSet(id, field, value.$delete, hierarchy)
+    }
   }
 
-  if (value.$add) {
-    addToSet(id, field, value.$add, update, hierarchy)
-  }
-  if (value.$delete) {
-    removeFromSet(id, field, value.$delete, hierarchy)
+  // if it's an object field, also set a set marker
+  if (field.indexOf('.') !== -1) {
+    redis.hset(id, field, '___selva_$set')
   }
 
   sendEvent(id, field, 'update')

--- a/test/getBasic.ts
+++ b/test/getBasic.ts
@@ -1009,7 +1009,7 @@ test.serial.only(
       }
     )
 
-    // await client.delete('root')
+    await client.delete('root')
 
     client.destroy()
   }

--- a/test/getBasic.ts
+++ b/test/getBasic.ts
@@ -977,8 +977,16 @@ test.serial.only(
       }
     })
 
-    // t.deepEqual(
     console.log(
+      await client.get({
+        $id: entry,
+        id: true,
+        title: { $inherit: true },
+        ding: { $inherit: true }
+      })
+    )
+    // t.deepEqual(
+    t.deepEqual(
       await client.get({
         $id: entry,
         id: true,
@@ -994,7 +1002,7 @@ test.serial.only(
           dang: {
             dung: 115
           },
-          dong: ['yesh', 'hello']
+          dung: 123
         }
       }
     )

--- a/test/getBasic.ts
+++ b/test/getBasic.ts
@@ -932,88 +932,85 @@ test.serial('get - $inherit', async t => {
   client.destroy()
 })
 
-test.serial.only(
-  'get - $inherit with object types does shallow merge',
-  async t => {
-    const client = connect({ port }, { loglevel: 'info' })
+test.serial('get - $inherit with object types does shallow merge', async t => {
+  const client = connect({ port }, { loglevel: 'info' })
 
-    const parentOfParent = await client.set({
-      type: 'lekkerType',
-      title: {
-        en: 'nice!',
-        de: 'dont want to inherit this'
+  const parentOfParent = await client.set({
+    type: 'lekkerType',
+    title: {
+      en: 'nice!',
+      de: 'dont want to inherit this'
+    },
+    ding: {
+      dang: {
+        dung: 9000
       },
-      ding: {
-        dang: {
-          dung: 9000
-        },
-        dong: ['hello', 'yesh'],
-        dung: 123
+      dong: ['hello', 'yesh'],
+      dung: 123
+    }
+  })
+
+  const parentEntry = await client.set({
+    type: 'lekkerType',
+    title: {
+      en: 'nice!',
+      de: 'dont want to inherit this'
+    },
+    parents: {
+      $add: [parentOfParent]
+    },
+    ding: {
+      dang: {
+        dung: 115
       }
-    })
+    }
+  })
 
-    const parentEntry = await client.set({
-      type: 'lekkerType',
-      title: {
-        en: 'nice!',
-        de: 'dont want to inherit this'
-      },
-      parents: {
-        $add: [parentOfParent]
-      },
-      ding: {
-        dang: {
-          dung: 115
-        }
-      }
-    })
+  const entry = await client.set({
+    type: 'lekkerType',
+    parents: {
+      $add: [parentEntry]
+    },
+    title: {
+      en: 'nice!'
+    }
+  })
 
-    const entry = await client.set({
-      type: 'lekkerType',
-      parents: {
-        $add: [parentEntry]
-      },
+  console.log(
+    await client.get({
+      $id: entry,
+      id: true,
+      title: { $inherit: true },
+      ding: { $inherit: true }
+    })
+  )
+  // t.deepEqual(
+  t.deepEqualIgnoreOrder(
+    await client.get({
+      $id: entry,
+      id: true,
+      title: { $inherit: true },
+      ding: { $inherit: true }
+    }),
+    {
+      id: entry,
       title: {
         en: 'nice!'
-      }
-    })
-
-    console.log(
-      await client.get({
-        $id: entry,
-        id: true,
-        title: { $inherit: true },
-        ding: { $inherit: true }
-      })
-    )
-    // t.deepEqual(
-    t.deepEqualIgnoreOrder(
-      await client.get({
-        $id: entry,
-        id: true,
-        title: { $inherit: true },
-        ding: { $inherit: true }
-      }),
-      {
-        id: entry,
-        title: {
-          en: 'nice!'
+      },
+      ding: {
+        dong: ['hello', 'yesh'],
+        dang: {
+          dung: 115
         },
-        ding: {
-          dong: ['hello', 'yesh'],
-          dang: {
-            dung: 115
-          },
-          dung: 123
-        }
+        dung: 123
       }
-    )
+    }
+  )
 
-    await client.delete('root')
+  await client.delete('root')
 
-    client.destroy()
-  }
-)
+  client.destroy()
+})
 
 // test.serial('get - $field (basic)', async t => {
 //   const client = connect({ port })

--- a/test/getBasic.ts
+++ b/test/getBasic.ts
@@ -119,10 +119,10 @@ test.before(async t => {
 })
 
 test.after(async _t => {
-  const client = connect({ port })
-  await client.delete('root')
-  await client.destroy()
-  await srv.destroy()
+  // const client = connect({ port })
+  // await client.delete('root')
+  // await client.destroy()
+  // await srv.destroy()
 })
 
 test.serial('get $value', async t => {
@@ -947,6 +947,7 @@ test.serial.only(
         dang: {
           dung: 9000
         },
+        dong: ['hello', 'yesh'],
         dung: 123
       }
     })
@@ -986,7 +987,7 @@ test.serial.only(
       })
     )
     // t.deepEqual(
-    t.deepEqual(
+    t.deepEqualIgnoreOrder(
       await client.get({
         $id: entry,
         id: true,
@@ -999,6 +1000,7 @@ test.serial.only(
           en: 'nice!'
         },
         ding: {
+          dong: ['hello', 'yesh'],
           dang: {
             dung: 115
           },
@@ -1007,7 +1009,7 @@ test.serial.only(
       }
     )
 
-    await client.delete('root')
+    // await client.delete('root')
 
     client.destroy()
   }


### PR DESCRIPTION
Shallow merging when inheriting object fields or nested object fields.

Stops inheriting when it has found all top level keys (since we always persist the closest matching (if by type or name) ancestor's values instead of overwriting always like JS impls of shallow merge). This means for longer chains we can at least stop if we've already found every key.

Also fixes `objectfield: true` and `objectField: { $inherit: true }`, etc. cases where the object contains a set or references type field or nested field. Also fixes delete so that it cleans up such object fields.