### PR TITLE
null check to oldField search

### DIFF
--- a/client/lua/src/schema/index.ts
+++ b/client/lua/src/schema/index.ts
@@ -195,7 +195,7 @@ function checkField(
     ) {
       if (
         // @ts-ignore
-        searchTypeChanged(searchRaw.type, oldField.search.type)
+        oldField.search && searchTypeChanged(searchRaw.type, oldField.search.type)
       ) {
         // TODO: add support for changing schema types', which means recreating index
         return `Can not change existing search types for ${path} in type ${type}, changing from ${cjson.encode(


### PR DESCRIPTION
Targeted to Fix the following Issue:
When search index is added to an old field in the schema.
Old Schema:
module.exports = {
type: 'timestamp',
}
New Schema:
module.exports = {
type: 'timestamp',
search: { type: ['NUMERIC', 'SORTABLE'] }
}
UpdateSchema command throws following error:
12|db | 2021-02-23T13:06:15: ReplyError: ERR Error running script (call to f_c545816098685cc5496530e85c8ac77be99fa5a2): @user_script:1089: user_script:1089: attempt to index field 'search' (a nil value)
12|db | 2021-02-23T13:06:15: at parseError (/home/vikas/repos/v2/node_modules/redis-parser/lib/parser.js:193:12)
12|db | 2021-02-23T13:06:15: at parseType (/home/vikas/repos/v2/node_modules/redis-parser/lib/parser.js:303:14) {
12|db | 2021-02-23T13:06:15: command: 'EVALSHA',
12|db | 2021-02-23T13:06:15: args: [
12|db | 2021-02-23T13:06:15: 'c545816098685cc5496530e85c8ac77be99fa5a2',
12|db | 2021-02-23T13:06:15: 0,
12|db | 2021-02-23T13:06:15: 'undefined:cb63e8d1-504c-4aac-a38c-ee40e7cea971',

As a fix added the null check.