### PR TITLE
rpn shouldn't alter a user provided SelvaSet

### DIFF
--- a/server/modules/selva/module/rpn.c
+++ b/server/modules/selva/module/rpn.c
@@ -1690,7 +1690,12 @@ enum rpn_error rpn_selvaset(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ct
         return RPN_ERR_TYPE;
     }
 
-    SelvaSet_Merge(out, res->set);
+    if (res->flags.regist) {
+        SelvaSet_Union(out->type, out, res->set, NULL);
+    } else {
+        /* Safe to move the strings. */
+        SelvaSet_Merge(out, res->set);
+    }
     free_rpn_operand(&res);
 
     return RPN_ERR_OK;


### PR DESCRIPTION
`res->set` might be coming directly from the input expression or
a register and we must not alter it in that case as it might be
reused multiple times. Therefore `SevaSet_Merge()` isn't always
the right function.