### PR TITLE
Fix passing long long values

### DIFF
--- a/client/src/set/fieldParsers/simple.ts
+++ b/client/src/set/fieldParsers/simple.ts
@@ -44,7 +44,7 @@ export const verifiers = {
   timestamp: (payload: 'now' | number) => {
     return (
       payload === 'now' ||
-      (typeof payload === 'number' && Number.isInteger(payload) && payload > 0)
+      (typeof payload === 'number' && Number.isInteger(payload))
     )
   },
   url: (payload: string) => {

--- a/client/src/set/modifyDataRecords.ts
+++ b/client/src/set/modifyDataRecords.ts
@@ -2,7 +2,7 @@ import { compile } from 'data-record'
 
 export const doubleDef = compile([{ name: 'd', type: 'double' }])
 
-export const longLongDef = compile([{ name: 'd', type: 'uint64' }])
+export const longLongDef = compile([{ name: 'd', type: 'int64' }])
 
 export const OPT_SET_TYPE = {
   char: 0,


### PR DESCRIPTION
- Timestamps can be negative (< 1970)
- Long long should be passed as `int64`