### PR TITLE
RPN: falsy result == empty set

### DIFF
--- a/server/modules/selva/module/rpn.c
+++ b/server/modules/selva/module/rpn.c
@@ -1735,18 +1735,20 @@ enum rpn_error rpn_selvaset(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ct
         return RPN_ERR_BADSTK;
     }
 
-    if (!res->set) {
+    if (res->set) {
+        if (res->flags.regist) {
+            SelvaSet_Union(out->type, out, res->set, NULL);
+        } else {
+            /* Safe to move the strings. */
+            SelvaSet_Merge(out, res->set);
+        }
+        free_rpn_operand(&res);
+    } else if (to_bool(res)) {
+        /* However, if res is falsy we interpret it as meaning an empty set. */
         free_rpn_operand(&res);
         return RPN_ERR_TYPE;
     }
 
-    if (res->flags.regist) {
-        SelvaSet_Union(out->type, out, res->set, NULL);
-    } else {
-        /* Safe to move the strings. */
-        SelvaSet_Merge(out, res->set);
-    }
-    free_rpn_operand(&res);
 
     return RPN_ERR_OK;
 }

--- a/server/modules/selva/module/selva_set.h
+++ b/server/modules/selva/module/selva_set.h
@@ -56,6 +56,10 @@ static inline int SelvaSet_isValidType(enum SelvaSetType type) {
     return type >= 0 && type < SELVA_SET_NR_TYPES;
 }
 
+static inline size_t SelvaSet_Size(struct SelvaSet *set) {
+    return set->size;
+}
+
 static inline void SelvaSet_Init(struct SelvaSet *set, enum SelvaSetType type) {
     set->type = type;
     set->size = 0;

--- a/server/modules/selva/test/units/test-rpn.c
+++ b/server/modules/selva/test/units/test-rpn.c
@@ -465,6 +465,28 @@ static char * test_selvaset_empty(void)
     return NULL;
 }
 
+static char * test_selvaset_empty_2(void)
+{
+    enum rpn_error err;
+    const char expr_str[] = "{\"a\"} {\"b\"} #0 P T";
+    int res;
+    struct SelvaSet set;
+
+    expr = rpn_compile(expr_str);
+    pu_assert("expr is created", expr);
+
+    err = rpn_bool(NULL, ctx, expr, &res);
+    pu_assert_equal("No error", err, RPN_ERR_OK);
+    pu_assert_equal("Resolves to false", res, 0);
+
+    SelvaSet_Init(&set, SELVA_SET_TYPE_RMSTRING);
+    err = rpn_selvaset(NULL, ctx, expr, &set);
+    pu_assert_equal("No error", err, RPN_ERR_OK);
+    pu_assert_equal("Returned empty set", SelvaSet_Size(&set), 0);
+
+    return NULL;
+}
+
 static char * test_selvaset_ill(void)
 {
     const char expr_str1[] = "{\"abc\",\"def\",\"verylongtextisalsoprettynice\",\"this is another one that is fairly long and with spaces\",\"nice\"";
@@ -501,5 +523,6 @@ void all_tests(void)
     pu_def_test(test_selvaset_inline, PU_RUN);
     pu_def_test(test_selvaset_union, PU_RUN);
     pu_def_test(test_selvaset_empty, PU_RUN);
+    pu_def_test(test_selvaset_empty_2, PU_RUN);
     pu_def_test(test_selvaset_ill, PU_RUN);
 }


### PR DESCRIPTION
When running `rpn_selvaset()` it's ok to interpret a falsy result
as an empty set.