### PR TITLE
Refactor subscriptions

### DIFF
--- a/server/modules/selva/module.c
+++ b/server/modules/selva/module.c
@@ -388,10 +388,10 @@ int SelvaCommand_Modify(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         return replyWithSelvaErrorf(ctx, err, "Failed to open the object for id: \"%s\"", id_str);
     }
 
-    const struct SelvaModify_HierarchyMetadata *metadata;
+    struct SelvaModify_HierarchyNode *node;
 
-    metadata = SelvaHierarchy_GetNodeMetadata(hierarchy, nodeId);
-    SelvaSubscriptions_FieldChangePrecheck(ctx, hierarchy, nodeId, metadata);
+    node = SelvaHierarchy_FindNode(hierarchy, nodeId);
+    SelvaSubscriptions_FieldChangePrecheck(ctx, hierarchy, node);
 
     if (!trigger_created && FISSET_NO_MERGE(flags)) {
         SelvaNode_ClearFields(ctx, obj);
@@ -776,7 +776,7 @@ int SelvaCommand_Modify(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
          * Hierarchy handles events for parents and children.
          */
         if (strcmp(field_str, "parents") && strcmp(field_str, "children")) {
-            SelvaSubscriptions_DeferFieldChangeEvents(ctx, hierarchy, nodeId, metadata, field_str, field_len);
+            SelvaSubscriptions_DeferFieldChangeEvents(ctx, hierarchy, node, field_str, field_len);
         }
 
 #if 0
@@ -840,13 +840,13 @@ int SelvaCommand_Modify(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             if (FISSET_CREATED_AT(flags)) {
                 SelvaObject_SetLongLongStr(obj, SELVA_CREATED_AT_FIELD, sizeof(SELVA_CREATED_AT_FIELD) - 1, now);
             }
-            Selva_Subscriptions_DeferTriggerEvents(ctx, hierarchy, nodeId, SELVA_SUBSCRIPTION_TRIGGER_TYPE_CREATED);
+            Selva_Subscriptions_DeferTriggerEvents(ctx, hierarchy, node, SELVA_SUBSCRIPTION_TRIGGER_TYPE_CREATED);
         } else {
             /*
              * If nodeId wasn't created by this command call then it was an
              * update.
              */
-            Selva_Subscriptions_DeferTriggerEvents(ctx, hierarchy, nodeId, SELVA_SUBSCRIPTION_TRIGGER_TYPE_UPDATED);
+            Selva_Subscriptions_DeferTriggerEvents(ctx, hierarchy, node, SELVA_SUBSCRIPTION_TRIGGER_TYPE_UPDATED);
         }
     }
 

--- a/server/modules/selva/module/edge.c
+++ b/server/modules/selva/module/edge.c
@@ -100,8 +100,8 @@ static struct EdgeField *alloc_EdgeField(const Selva_NodeId src_node_id, const s
     return edgeField;
 }
 
-struct EdgeField *Edge_GetField(struct SelvaModify_HierarchyNode *src_node, const char *field_name_str, size_t field_name_len) {
-    struct SelvaModify_HierarchyMetadata *src_metadata;
+struct EdgeField *Edge_GetField(const struct SelvaModify_HierarchyNode *src_node, const char *field_name_str, size_t field_name_len) {
+    const struct SelvaModify_HierarchyMetadata *src_metadata;
     struct EdgeField *src_edge_field;
     int err;
 
@@ -298,7 +298,7 @@ int Edge_Add(
         }
     }
 
-    SelvaSubscriptions_InheritEdge(ctx, hierarchy, src_node, dst_node, field_name_str, field_name_len);
+    SelvaSubscriptions_InheritEdge(hierarchy, src_node, dst_node, field_name_str, field_name_len);
     /*
      * Note that the regular change events for edges are only sent by the modify
      * command. Therefore we expect we don't need to do anything here.
@@ -401,9 +401,9 @@ static void remove_related_edge_markers(struct RedisModuleCtx *ctx, struct Selva
                 src_marker->sub == dst_marker->sub &&
                 !memcmp(src_marker->node_id, src_node_id, SELVA_NODE_ID_SIZE)) {
                 /* RFE Is it a bit ugly to do this here? */
-                dst_marker->marker_action(hierarchy, dst_marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY);
+                dst_marker->marker_action(hierarchy, dst_marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY, dst_node);
 
-                (void)SelvaSubscriptions_DeleteMarker(ctx, hierarchy, dst_marker->sub, dst_marker->marker_id);
+                (void)SelvaSubscriptions_DeleteMarkerByPtr(ctx, hierarchy, dst_marker);
             }
         }
     }

--- a/server/modules/selva/module/edge.c
+++ b/server/modules/selva/module/edge.c
@@ -298,7 +298,7 @@ int Edge_Add(
         }
     }
 
-    SelvaSubscriptions_InheritEdge(hierarchy, src_node, dst_node, field_name_str, field_name_len);
+    SelvaSubscriptions_InheritEdge(ctx, hierarchy, src_node, dst_node, field_name_str, field_name_len);
     /*
      * Note that the regular change events for edges are only sent by the modify
      * command. Therefore we expect we don't need to do anything here.
@@ -401,7 +401,8 @@ static void remove_related_edge_markers(struct RedisModuleCtx *ctx, struct Selva
                 src_marker->sub == dst_marker->sub &&
                 !memcmp(src_marker->node_id, src_node_id, SELVA_NODE_ID_SIZE)) {
                 /* RFE Is it a bit ugly to do this here? */
-                dst_marker->marker_action(hierarchy, dst_marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY, dst_node);
+                /* TODO Should it be dst_node or src_node here? */
+                dst_marker->marker_action(ctx, hierarchy, dst_marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY, dst_node);
 
                 (void)SelvaSubscriptions_DeleteMarkerByPtr(ctx, hierarchy, dst_marker);
             }

--- a/server/modules/selva/module/edge.h
+++ b/server/modules/selva/module/edge.h
@@ -139,7 +139,7 @@ const struct EdgeFieldConstraint *Edge_GetConstraint(const struct EdgeFieldConst
  * @param node is a pointer to the node the lookup should be applied to. Can be NULL.
  * @returns A pointer to an EdgeField if node is set and the field is found; Otherwise NULL.
  */
-struct EdgeField *Edge_GetField(struct SelvaModify_HierarchyNode *node, const char *field_name_str, size_t field_name_len);
+struct EdgeField *Edge_GetField(const struct SelvaModify_HierarchyNode *node, const char *field_name_str, size_t field_name_len);
 
 /**
  * Check if an EdgeField has a reference to dst_node.

--- a/server/modules/selva/module/hierarchy.c
+++ b/server/modules/selva/module/hierarchy.c
@@ -594,8 +594,7 @@ static int cross_insert_children(
              * Inherit markers from the parent node to the new child.
              */
             SelvaSubscriptions_InheritParent(
-                ctx,
-                hierarchy,
+                ctx, hierarchy,
                 child->id, &child->metadata,
                 SVector_Size(&child->children),
                 node);
@@ -604,8 +603,7 @@ static int cross_insert_children(
              * Inherit markers from the new child to the parent node.
              */
             SelvaSubscriptions_InheritChild(
-                ctx,
-                hierarchy,
+                ctx, hierarchy,
                 node->id, &node->metadata,
                 SVector_Size(&node->parents),
                 child);
@@ -704,8 +702,7 @@ static int cross_insert_parents(
              * Inherit subscription markers from the new parent to the node.
              */
             SelvaSubscriptions_InheritParent(
-                ctx,
-                hierarchy,
+                ctx, hierarchy,
                 node->id, &node->metadata,
                 SVector_Size(&node->children),
                 parent);
@@ -714,8 +711,7 @@ static int cross_insert_parents(
              * Inherit subscription markers from the node to the new parent.
              */
             SelvaSubscriptions_InheritChild(
-                ctx,
-                hierarchy,
+                ctx, hierarchy,
                 parent->id, &parent->metadata,
                 SVector_Size(&parent->parents),
                 node);

--- a/server/modules/selva/module/hierarchy.c
+++ b/server/modules/selva/module/hierarchy.c
@@ -405,7 +405,7 @@ static void del_node(RedisModuleCtx *ctx, SelvaModify_Hierarchy *hierarchy, Selv
     }
 
     removeRelationships(ctx, hierarchy, node, RELATIONSHIP_PARENT);
-    SelvaSubscriptions_DeferHierarchyDeletionEvents(hierarchy, node);
+    SelvaSubscriptions_DeferHierarchyDeletionEvents(ctx, hierarchy, node);
 
     /*
      * Never delete the root node.
@@ -594,6 +594,7 @@ static int cross_insert_children(
              * Inherit markers from the parent node to the new child.
              */
             SelvaSubscriptions_InheritParent(
+                ctx,
                 hierarchy,
                 child->id, &child->metadata,
                 SVector_Size(&child->children),
@@ -603,6 +604,7 @@ static int cross_insert_children(
              * Inherit markers from the new child to the parent node.
              */
             SelvaSubscriptions_InheritChild(
+                ctx,
                 hierarchy,
                 node->id, &node->metadata,
                 SVector_Size(&node->parents),
@@ -702,6 +704,7 @@ static int cross_insert_parents(
              * Inherit subscription markers from the new parent to the node.
              */
             SelvaSubscriptions_InheritParent(
+                ctx,
                 hierarchy,
                 node->id, &node->metadata,
                 SVector_Size(&node->children),
@@ -711,6 +714,7 @@ static int cross_insert_parents(
              * Inherit subscription markers from the node to the new parent.
              */
             SelvaSubscriptions_InheritChild(
+                ctx,
                 hierarchy,
                 parent->id, &parent->metadata,
                 SVector_Size(&parent->parents),

--- a/server/modules/selva/module/hierarchy.h
+++ b/server/modules/selva/module/hierarchy.h
@@ -158,7 +158,13 @@ int SelvaHierarchy_NodeExists(SelvaModify_Hierarchy *hierarchy, const Selva_Node
 char *SelvaHierarchy_GetNodeId(Selva_NodeId id, const struct SelvaModify_HierarchyNode *node);
 char *SelvaHierarchy_GetNodeType(char type[SELVA_NODE_TYPE_SIZE], const struct SelvaModify_HierarchyNode *node);
 
-struct SelvaModify_HierarchyMetadata *SelvaHierarchy_GetNodeMetadataByPtr(struct SelvaModify_HierarchyNode *node);
+const struct SelvaModify_HierarchyMetadata *_SelvaHierarchy_GetNodeMetadataByConstPtr(const struct SelvaModify_HierarchyNode *node);
+struct SelvaModify_HierarchyMetadata *_SelvaHierarchy_GetNodeMetadataByPtr(struct SelvaModify_HierarchyNode *node);
+#define SelvaHierarchy_GetNodeMetadataByPtr(node) _Generic((node), \
+        const struct SelvaModify_HierarchyNode *: _SelvaHierarchy_GetNodeMetadataByConstPtr, \
+        struct SelvaModify_HierarchyNode *: _SelvaHierarchy_GetNodeMetadataByPtr \
+        )(node)
+
 struct SelvaModify_HierarchyMetadata *SelvaHierarchy_GetNodeMetadata(
         SelvaModify_Hierarchy *hierarchy,
         const Selva_NodeId id);
@@ -314,7 +320,7 @@ int SelvaModify_TraverseArray(
         const char *ref_field_str,
         size_t ref_field_len,
         const struct SelvaModify_ArrayObjectCallback *cb);
-int SelvaHierarchy_IsNonEmptyField(struct SelvaModify_HierarchyNode *node, const char *field_str, size_t field_len);
+int SelvaHierarchy_IsNonEmptyField(const struct SelvaModify_HierarchyNode *node, const char *field_str, size_t field_len);
 
 /*
  * hierarchy_reply.c

--- a/server/modules/selva/module/rpn.c
+++ b/server/modules/selva/module/rpn.c
@@ -927,7 +927,7 @@ static enum rpn_error rpn_op_exists(struct RedisModuleCtx *redis_ctx, struct rpn
     OPERAND(ctx, field);
     const char *field_str = OPERAND_GET_S(field);
     const size_t field_len = OPERAND_GET_S_LEN(field);
-    struct SelvaModify_HierarchyNode *node = ctx->node;
+    const struct SelvaModify_HierarchyNode *node = ctx->node;
 
     /*
      * First check if it's a non-empty hierarchy/edge field.
@@ -1079,7 +1079,7 @@ static enum rpn_error rpn_op_ffirst(struct RedisModuleCtx *redis_ctx __unused, s
     struct SelvaSet *set_a;
     RESULT_OPERAND(result);
     struct SelvaSetElement *el;
-    struct SelvaModify_HierarchyNode *node = ctx->node;
+    const struct SelvaModify_HierarchyNode *node = ctx->node;
 
     if (!node) {
         return RPN_ERR_ILLOPN;
@@ -1124,7 +1124,7 @@ static enum rpn_error rpn_op_aon(struct RedisModuleCtx *redis_ctx __unused, stru
     OPERAND(ctx, a);
     struct SelvaSet *set_a;
     struct SelvaSetElement *el;
-    struct SelvaModify_HierarchyNode *node = ctx->node;
+    const struct SelvaModify_HierarchyNode *node = ctx->node;
 
     if (!node) {
         return RPN_ERR_ILLOPN;

--- a/server/modules/selva/module/rpn.h
+++ b/server/modules/selva/module/rpn.h
@@ -36,7 +36,7 @@ struct rpn_operand;
 struct rpn_ctx {
     int depth;
     int nr_reg;
-    struct SelvaModify_HierarchyNode *node; /*!< A pointer to the current hierarchy node set with rpn_set_hierarchy_node(). */
+    const struct SelvaModify_HierarchyNode *node; /*!< A pointer to the current hierarchy node set with rpn_set_hierarchy_node(). */
     struct RedisModuleKey *redis_key; /*!< Redis key of the current node object. */
     struct SelvaObject *obj; /*!< Selva object of the current node. */
     struct RedisModuleString *rms_id;  /*!< This holds the id of redis_hkey. */
@@ -72,7 +72,7 @@ void rpn_destroy(struct rpn_ctx *ctx);
  * An operand requiring a node pointer will return RPN_ERR_ILLOPN if the pointer
  * is not set.
  */
-static inline void rpn_set_hierarchy_node(struct rpn_ctx *ctx, struct SelvaModify_HierarchyNode *node) {
+static inline void rpn_set_hierarchy_node(struct rpn_ctx *ctx, const struct SelvaModify_HierarchyNode *node) {
     ctx->node = node;
 }
 

--- a/server/modules/selva/module/subscriptions.c
+++ b/server/modules/selva/module/subscriptions.c
@@ -27,6 +27,11 @@ struct Selva_Subscription {
     SVector markers; /* struct Selva_SubscriptionMarker */
 };
 
+struct set_node_marker_data {
+    SelvaModify_Hierarchy *hierarchy;
+    struct Selva_SubscriptionMarker *marker;
+};
+
 static const struct SelvaArgParser_EnumType trigger_event_types[] = {
     {
         .name = "created",
@@ -46,6 +51,7 @@ static const struct SelvaArgParser_EnumType trigger_event_types[] = {
     }
 };
 
+static struct Selva_Subscription *find_sub(SelvaModify_Hierarchy *hierarchy, Selva_SubscriptionId sub_id);
 static void clear_node_sub(RedisModuleCtx *ctx, struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, const Selva_NodeId node_id);
 
 static int marker_svector_compare(const void ** restrict a_raw, const void ** restrict b_raw) {
@@ -73,11 +79,9 @@ static int subscription_rb_compare(const struct Selva_Subscription *a, const str
 RB_PROTOTYPE_STATIC(hierarchy_subscriptions_tree, Selva_Subscription, _sub_index_entry, subscription_rb_compare)
 RB_GENERATE_STATIC(hierarchy_subscriptions_tree, Selva_Subscription, _sub_index_entry, subscription_rb_compare)
 
-static void defer_update_event(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags);
-static void defer_trigger_event(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags);
-static void defer_event_for_traversing_markers(struct SelvaModify_Hierarchy *hierarchy,
-                                               const Selva_NodeId node_id,
-                                               const struct SelvaModify_HierarchyMetadata *metadata);
+static void defer_update_event(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags, const struct SelvaModify_HierarchyNode *node);
+static void defer_trigger_event(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags, const struct SelvaModify_HierarchyNode *node);
+static void defer_event_for_traversing_markers(struct SelvaModify_Hierarchy *hierarchy, const struct SelvaModify_HierarchyNode *node);
 
 /**
  * The given marker flags matches to a hierarchy marker of any kind.
@@ -165,8 +169,9 @@ static int Selva_SubscriptionFieldMatch(const struct Selva_SubscriptionMarker *m
 /**
  * Match subscription marker with the RPN expression filter.
  */
-static int Selva_SubscriptionFilterMatch(RedisModuleCtx *ctx, const Selva_NodeId node_id, struct Selva_SubscriptionMarker *marker) {
+int Selva_SubscriptionFilterMatch(RedisModuleCtx *ctx, const struct SelvaModify_HierarchyNode *node, struct Selva_SubscriptionMarker *marker) {
     struct rpn_ctx *filter_ctx = marker->filter_ctx;
+    Selva_NodeId node_id;
     int res = 0;
     int err;
 
@@ -175,6 +180,9 @@ static int Selva_SubscriptionFilterMatch(RedisModuleCtx *ctx, const Selva_NodeId
         return 1;
     }
 
+    SelvaHierarchy_GetNodeId(node_id, node);
+
+    rpn_set_hierarchy_node(filter_ctx, node);
     rpn_set_reg(filter_ctx, 0, node_id, SELVA_NODE_ID_SIZE, 0);
     err = rpn_bool(ctx, filter_ctx, marker->filter_expression, &res);
     if (err) {
@@ -282,7 +290,7 @@ static void do_sub_marker_removal(RedisModuleCtx *ctx, SelvaModify_Hierarchy *hi
     destroy_marker(marker);
 }
 
-int SelvaSubscriptions_DeleteMarker(RedisModuleCtx *ctx, SelvaModify_Hierarchy *hierarchy, struct Selva_Subscription *sub, Selva_SubscriptionMarkerId marker_id) {
+int delete_marker(RedisModuleCtx *ctx, SelvaModify_Hierarchy *hierarchy, struct Selva_Subscription *sub, Selva_SubscriptionMarkerId marker_id) {
     struct Selva_SubscriptionMarker find = {
         .marker_id = marker_id,
         .sub = sub,
@@ -291,12 +299,28 @@ int SelvaSubscriptions_DeleteMarker(RedisModuleCtx *ctx, SelvaModify_Hierarchy *
 
     marker = SVector_Remove(&sub->markers, &find);
     if (!marker) {
-        return SELVA_ENOENT;
+        return SELVA_SUBSCRIPTIONS_ENOENT;
     }
 
     do_sub_marker_removal(ctx, hierarchy, marker);
     return 0;
 }
+
+int SelvaSubscriptions_DeleteMarker(RedisModuleCtx *ctx, SelvaModify_Hierarchy *hierarchy, Selva_SubscriptionId sub_id, Selva_SubscriptionMarkerId marker_id) {
+    struct Selva_Subscription *sub;
+
+    sub = find_sub(hierarchy, sub_id);
+    if (!sub) {
+        return SELVA_SUBSCRIPTIONS_ENOENT;
+    }
+
+    return delete_marker(ctx, hierarchy, sub, marker_id);
+}
+
+int SelvaSubscriptions_DeleteMarkerByPtr(RedisModuleCtx *ctx, SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker) {
+    return delete_marker(ctx, hierarchy, marker->sub, marker->marker_id);
+}
+
 
 /**
  * Remove and destroy all markers of a subscription.
@@ -471,7 +495,9 @@ static void clear_marker(struct Selva_SubscriptionMarkers *sub_markers, struct S
  */
 static int set_node_marker_cb(struct SelvaModify_HierarchyNode *node, void *arg) {
     struct SelvaModify_HierarchyMetadata *metadata;
-    struct Selva_SubscriptionMarker *marker = (struct Selva_SubscriptionMarker *)arg;
+    struct set_node_marker_data *data = (struct set_node_marker_data *)arg;
+    SelvaModify_Hierarchy *hierarchy = data->hierarchy;
+    struct Selva_SubscriptionMarker *marker = data->marker;
 
     if (marker->dir == SELVA_HIERARCHY_TRAVERSAL_REF) {
         Selva_NodeId node_id;
@@ -499,6 +525,10 @@ static int set_node_marker_cb(struct SelvaModify_HierarchyNode *node, void *arg)
             (int)SELVA_NODE_ID_SIZE, node_id);
 #endif
     set_marker(&metadata->sub_markers, marker);
+
+    if (marker->marker_flags & SELVA_SUBSCRIPTION_FLAG_REFRESH) {
+        marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_REFRESH, node);
+    }
 
     return 0;
 }
@@ -627,6 +657,10 @@ static int marker_set_fields(struct Selva_SubscriptionMarker *marker, const char
     return 0;
 }
 
+static void marker_set_action_owner_ctx(struct Selva_SubscriptionMarker *marker, void *owner_ctx) {
+    marker->marker_action_owner_ctx = owner_ctx;
+}
+
 /**
  * Set ref_field for the marker.
  * The traversal direction must have been set to one of the ones requiring a ref
@@ -737,6 +771,60 @@ out:
     return err;
 }
 
+int SelvaSubscriptions_AddCallbackMarker(
+        SelvaModify_Hierarchy *hierarchy,
+        Selva_SubscriptionId sub_id,
+        Selva_SubscriptionMarkerId marker_id,
+        unsigned short marker_flags,
+        Selva_NodeId node_id,
+        enum SelvaTraversal dir,
+        const char *dir_field,
+        struct rpn_expression *dir_expression,
+        struct rpn_expression *filter,
+        Selva_SubscriptionMarkerAction *callback,
+        void *owner_ctx
+    ) {
+    struct rpn_ctx *filter_ctx = NULL;
+    struct Selva_SubscriptionMarker *marker;
+    int err = 0;
+
+    if (SelvaSubscriptions_GetMarker(hierarchy, sub_id, marker_id)) {
+        /* Marker already created. */
+        return SELVA_SUBSCRIPTIONS_EEXIST;
+    }
+
+    if (filter) {
+        filter_ctx = rpn_init(1);
+        if (!filter_ctx) {
+            return SELVA_ENOMEM;
+        }
+    }
+
+    err = new_marker(hierarchy, sub_id, marker_id, marker_flags, callback, &marker);
+    if (err) {
+        rpn_destroy(filter_ctx);
+        return SELVA_ENOMEM;
+    }
+
+    marker_set_node_id(marker, node_id);
+    marker_set_dir(marker, dir);
+
+    if (dir == SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION && dir_expression) {
+        marker_set_traversal_expression(marker, dir_expression);
+    } else if (dir_field) {
+        marker_set_ref_field(marker, dir_field);
+    }
+
+
+    if (filter) {
+        marker_set_filter(marker, filter_ctx, filter);
+    }
+
+    marker_set_action_owner_ctx(marker, owner_ctx);
+
+    return err;
+}
+
 struct Selva_SubscriptionMarker *SelvaSubscriptions_GetMarker(
         struct SelvaModify_Hierarchy *hierarchy,
         Selva_SubscriptionId sub_id,
@@ -827,6 +915,50 @@ fail:
     return 0;
 }
 
+static int refresh_marker(
+        RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        struct Selva_SubscriptionMarker *marker) {
+    if (marker->dir == SELVA_HIERARCHY_TRAVERSAL_NONE ||
+        (marker->marker_flags & SELVA_SUBSCRIPTION_FLAG_DETACH)) {
+        /*
+         * This is a non-traversing marker but it needs to exist in the
+         * detached markers.
+         */
+        set_marker(&hierarchy->subs.detached_markers, marker);
+
+        return 0;
+    } else {
+        struct set_node_marker_data cb_data = {
+            .hierarchy = hierarchy,
+            .marker = marker,
+        };
+        struct SelvaModify_HierarchyCallback cb = {
+            .node_cb = set_node_marker_cb,
+            .node_arg = &cb_data,
+        };
+
+        /*
+         * Set subscription markers.
+         */
+        return SelvaSubscriptions_TraverseMarker(ctx, hierarchy, marker, &cb);
+    }
+}
+
+int SelvaSubscriptions_RefreshByMarkerId(
+        RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        Selva_SubscriptionId sub_id,
+        Selva_SubscriptionMarkerId marker_id) {
+    struct Selva_SubscriptionMarker *marker;
+    marker = SelvaSubscriptions_GetMarker(hierarchy, sub_id, marker_id);
+    if (!marker) {
+        return SELVA_SUBSCRIPTIONS_ENOENT;
+    }
+
+    return refresh_marker(ctx, hierarchy, marker);
+}
+
 static int refreshSubscription(RedisModuleCtx *ctx, struct SelvaModify_Hierarchy *hierarchy, struct Selva_Subscription *sub) {
     struct SVectorIterator it;
     struct Selva_SubscriptionMarker *marker;
@@ -836,26 +968,9 @@ static int refreshSubscription(RedisModuleCtx *ctx, struct SelvaModify_Hierarchy
 
     SVector_ForeachBegin(&it, &sub->markers);
     while ((marker = SVector_Foreach(&it))) {
-        if (marker->dir == SELVA_HIERARCHY_TRAVERSAL_NONE ||
-                (marker->marker_flags & SELVA_SUBSCRIPTION_FLAG_DETACH)) {
-            /*
-             * This is a non-traversing marker but it needs to exist in the
-             * detached markers.
-             */
-            set_marker(&hierarchy->subs.detached_markers, marker);
-            continue;
-        }
-
         int err;
-        struct SelvaModify_HierarchyCallback cb = {
-            .node_cb = set_node_marker_cb,
-            .node_arg = marker,
-        };
 
-        /*
-         * Set subscription markers.
-         */
-        err = SelvaSubscriptions_TraverseMarker(ctx, hierarchy, marker, &cb);
+        err = refresh_marker(ctx, hierarchy, marker);
         if (err) {
             /* Report just the last error. */
             res = err;
@@ -994,7 +1109,7 @@ void SelvaSubscriptions_ClearAllMarkers(
     while ((marker = SVector_Foreach(&it))) {
         assert(marker->sub);
         clear_node_sub(ctx, hierarchy, marker, node_id);
-        marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CL_HIERARCHY | SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY);
+        marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CL_HIERARCHY | SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY, node);
     }
     SVector_Clear(&metadata->sub_markers.vec);
 }
@@ -1010,27 +1125,29 @@ void SelvaSubscriptions_DestroyDeferredEvents(struct SelvaModify_Hierarchy *hier
 }
 
 void SelvaSubscriptions_InheritParent(
-        RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         const Selva_NodeId node_id __unused,
         struct SelvaModify_HierarchyMetadata *node_metadata,
         size_t node_nr_children,
-        const Selva_NodeId parent_id,
-        struct SelvaModify_HierarchyMetadata *parent_metadata) {
+        struct SelvaModify_HierarchyNode *parent) {
     /*
      * Trigger all relevant subscriptions to make sure the subscriptions are
      * propagated properly.
      */
     if (node_nr_children > 0) {
-        defer_event_for_traversing_markers(hierarchy, parent_id, parent_metadata);
+        defer_event_for_traversing_markers(hierarchy, parent);
     } else {
+        Selva_NodeId parent_id;
         struct SVectorIterator it;
         struct Selva_SubscriptionMarker *marker;
         struct Selva_SubscriptionMarkers *node_sub_markers = &node_metadata->sub_markers;
+
+        SelvaHierarchy_GetNodeId(parent_id, parent);
+
         /*
          * Note that normally root markers are detached and don't need to be inherited.
          */
-        SVector *markers_vec = &parent_metadata->sub_markers.vec;
+        const SVector *markers_vec = &SelvaHierarchy_GetNodeMetadataByPtr(parent)->sub_markers.vec;
 
         SVector_ForeachBegin(&it, markers_vec);
         while ((marker = SVector_Foreach(&it))) {
@@ -1064,28 +1181,30 @@ void SelvaSubscriptions_InheritParent(
 }
 
 void SelvaSubscriptions_InheritChild(
-        RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         const Selva_NodeId node_id __unused,
         struct SelvaModify_HierarchyMetadata *node_metadata,
         size_t node_nr_parents,
-        const Selva_NodeId child_id,
-        struct SelvaModify_HierarchyMetadata *child_metadata) {
+        struct SelvaModify_HierarchyNode *child) {
     /*
      * Trigger all relevant subscriptions to make sure the subscriptions are
      * propagated properly.
      */
     if (node_nr_parents > 0) {
-        defer_event_for_traversing_markers(hierarchy, child_id, child_metadata);
+        defer_event_for_traversing_markers(hierarchy, child);
     } else {
+        Selva_NodeId child_id;
         struct SVectorIterator it;
         struct Selva_SubscriptionMarker *marker;
+        struct Selva_SubscriptionMarkers *node_sub_markers;
+
         /*
          * Note that normally root markers are detached and don't need to be inherited.
          */
-        struct Selva_SubscriptionMarkers *node_sub_markers = &node_metadata->sub_markers;
+        node_sub_markers = &node_metadata->sub_markers;
+        SelvaHierarchy_GetNodeId(child_id, child);
 
-        SVector_ForeachBegin(&it, &child_metadata->sub_markers.vec);
+        SVector_ForeachBegin(&it, &SelvaHierarchy_GetNodeMetadataByPtr(child)->sub_markers.vec);
         while ((marker = SVector_Foreach(&it))) {
             switch (marker->dir) {
             case SELVA_HIERARCHY_TRAVERSAL_BFS_ANCESTORS:
@@ -1110,7 +1229,6 @@ void SelvaSubscriptions_InheritChild(
 }
 
 void SelvaSubscriptions_InheritEdge(
-        RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         struct SelvaModify_HierarchyNode *src_node,
         struct SelvaModify_HierarchyNode *dst_node,
@@ -1143,11 +1261,11 @@ void SelvaSubscriptions_InheritEdge(
      * doing this.
      */
     if (traversing && Edge_GetField(dst_node, field_str, field_len)) {
-        defer_event_for_traversing_markers(hierarchy, dst_node_id, dst_metadata);
+        defer_event_for_traversing_markers(hierarchy, dst_node);
     }
 }
 
-static void defer_update_event(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags __unused) {
+static void defer_update_event(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags __unused, const struct SelvaModify_HierarchyNode *node __unused) {
     struct SelvaSubscriptions_DeferredEvents *def = &hierarchy->subs.deferred_events;
     struct Selva_Subscription *sub = marker->sub;
 
@@ -1156,7 +1274,7 @@ static void defer_update_event(struct SelvaModify_Hierarchy *hierarchy, struct S
     }
 }
 
-static void defer_trigger_event(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags __unused) {
+static void defer_trigger_event(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags __unused, const struct SelvaModify_HierarchyNode *node __unused) {
     struct SelvaSubscriptions_DeferredEvents *def = &hierarchy->subs.deferred_events;
 
     if (SVector_IsInitialized(&def->triggers)) {
@@ -1207,39 +1325,44 @@ void SelvaSubscriptions_DeferMissingAccessorEvents(struct SelvaModify_Hierarchy 
  * Defer event if a marker is traversing marker.
  * Use defer_event_for_traversing_markers() instead of this function.
  */
-static void defer_traversing(struct SelvaModify_Hierarchy *hierarchy,
-                             const struct Selva_SubscriptionMarkers *sub_markers) {
+static void defer_traversing(
+        struct SelvaModify_Hierarchy *hierarchy,
+        const struct SelvaModify_HierarchyNode *node,
+        const struct Selva_SubscriptionMarkers *sub_markers) {
     struct SVectorIterator it;
     struct Selva_SubscriptionMarker *marker;
 
     SVector_ForeachBegin(&it, &sub_markers->vec);
     while ((marker = SVector_Foreach(&it))) {
         if (marker->dir != SELVA_HIERARCHY_TRAVERSAL_NONE) {
-            marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY);
+            marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY, node);
         }
     }
 }
 
-static void defer_event_for_traversing_markers(struct SelvaModify_Hierarchy *hierarchy,
-                                               const Selva_NodeId node_id,
-                                               const struct SelvaModify_HierarchyMetadata *metadata) {
+static void defer_event_for_traversing_markers(struct SelvaModify_Hierarchy *hierarchy, const struct SelvaModify_HierarchyNode *node) {
     /* Detached markers. */
-    defer_traversing(hierarchy, &hierarchy->subs.detached_markers);
+    defer_traversing(hierarchy, node, &hierarchy->subs.detached_markers);
 
-    if (!metadata) {
-        fprintf(stderr, "%s:%d: Node metadata missing %.*s\n",
+    /* RFE Is this necessary? */
+    if (!node) {
+        Selva_NodeId node_id;
+
+        SelvaHierarchy_GetNodeId(node_id, node);
+        fprintf(stderr, "%s:%d: Node pointer missing %.*s\n",
                 __FILE__, __LINE__, (int)SELVA_NODE_ID_SIZE, node_id);
         return;
     }
 
     /* Markers on the node. */
-    defer_traversing(hierarchy, &metadata->sub_markers);
+    defer_traversing(hierarchy, node, &SelvaHierarchy_GetNodeMetadataByPtr(node)->sub_markers);
 }
 
-static void defer_hierarchy_events(RedisModuleCtx *ctx,
-                                   struct SelvaModify_Hierarchy *hierarchy,
-                                   const Selva_NodeId node_id,
-                                   const struct Selva_SubscriptionMarkers *sub_markers) {
+static void defer_hierarchy_events(
+        RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        const struct SelvaModify_HierarchyNode *node,
+        const struct Selva_SubscriptionMarkers *sub_markers) {
     if (isHierarchyMarker(sub_markers->flags_filter)) {
         struct SVectorIterator it;
         struct Selva_SubscriptionMarker *marker;
@@ -1253,33 +1376,42 @@ static void defer_hierarchy_events(RedisModuleCtx *ctx,
              * marker filter.
              */
             if (isHierarchyMarker(marker->marker_flags) &&
-                Selva_SubscriptionFilterMatch(ctx, node_id, marker)) {
-                marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY);
+                Selva_SubscriptionFilterMatch(ctx, node, marker)) {
+                marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY, node);
             }
         }
     }
 }
 
-void SelvaSubscriptions_DeferHierarchyEvents(RedisModuleCtx *ctx,
-                                             struct SelvaModify_Hierarchy *hierarchy,
-                                             const Selva_NodeId node_id,
-                                             const struct SelvaModify_HierarchyMetadata *metadata) {
-    /* Detached markers. */
-    defer_hierarchy_events(ctx, hierarchy, node_id, &hierarchy->subs.detached_markers);
+void SelvaSubscriptions_DeferHierarchyEvents(
+        RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        const struct SelvaModify_HierarchyNode *node) {
+    const struct SelvaModify_HierarchyMetadata *metadata;
 
-    if (!metadata) {
-        fprintf(stderr, "%s:%d: Node metadata missing %.*s\n",
+    /* Detached markers. */
+    defer_hierarchy_events(ctx, hierarchy, node, &hierarchy->subs.detached_markers);
+
+    /* RFE is this still needed? */
+    if (!node) {
+        Selva_NodeId node_id;
+
+        SelvaHierarchy_GetNodeId(node_id, node);
+        fprintf(stderr, "%s:%d: Node pointer missing %.*s\n",
                 __FILE__, __LINE__, (int)SELVA_NODE_ID_SIZE, node_id);
         return;
     }
 
+    metadata = SelvaHierarchy_GetNodeMetadataByPtr(node);
+
     /* Markers on the node. */
-    defer_hierarchy_events(ctx, hierarchy, node_id, &metadata->sub_markers);
+    defer_hierarchy_events(ctx, hierarchy, node, &metadata->sub_markers);
 }
 
-static void defer_hierarchy_deletion_events(struct SelvaModify_Hierarchy *hierarchy,
-                                            const Selva_NodeId node_id __unused,
-                                            const struct Selva_SubscriptionMarkers *sub_markers) {
+static void defer_hierarchy_deletion_events(
+        struct SelvaModify_Hierarchy *hierarchy,
+        const struct SelvaModify_HierarchyNode *node,
+        const struct Selva_SubscriptionMarkers *sub_markers) {
     if (isHierarchyMarker(sub_markers->flags_filter)) {
         struct SVectorIterator it;
         struct Selva_SubscriptionMarker *marker;
@@ -1291,7 +1423,7 @@ static void defer_hierarchy_deletion_events(struct SelvaModify_Hierarchy *hierar
              * field subscriptions or inhibits.
              */
             if (isHierarchyMarker(marker->marker_flags)) {
-                marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY);
+                marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CH_HIERARCHY, node);
             }
         }
     }
@@ -1299,19 +1431,26 @@ static void defer_hierarchy_deletion_events(struct SelvaModify_Hierarchy *hierar
 
 void SelvaSubscriptions_DeferHierarchyDeletionEvents(
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
-        const struct SelvaModify_HierarchyMetadata *metadata) {
-    /* Detached markers. */
-    defer_hierarchy_deletion_events(hierarchy, node_id, &hierarchy->subs.detached_markers);
+        const struct SelvaModify_HierarchyNode *node) {
+    const struct SelvaModify_HierarchyMetadata *metadata;
 
-    if (!metadata) {
-        fprintf(stderr, "%s:%d: Node metadata missing %.*s\n",
+    /* Detached markers. */
+    defer_hierarchy_deletion_events(hierarchy, node, &hierarchy->subs.detached_markers);
+
+    /* RFE is this still needed? */
+    if (!node) {
+        Selva_NodeId node_id;
+
+        SelvaHierarchy_GetNodeId(node_id, node);
+        fprintf(stderr, "%s:%d: Node pointer missing %.*s\n",
                 __FILE__, __LINE__, (int)SELVA_NODE_ID_SIZE, node_id);
         return;
     }
 
+    metadata = SelvaHierarchy_GetNodeMetadataByPtr(node);
+
     /* Markers on the node. */
-    defer_hierarchy_deletion_events(hierarchy, node_id, &metadata->sub_markers);
+    defer_hierarchy_deletion_events(hierarchy, node, &metadata->sub_markers);
 }
 
 static void defer_alias_change_events(
@@ -1325,6 +1464,10 @@ static void defer_alias_change_events(
         return;
     }
 
+    const struct SelvaModify_HierarchyNode *node;
+
+    node = SelvaHierarchy_FindNode(hierarchy, node_id);
+
     struct SVectorIterator it;
     struct Selva_SubscriptionMarker *marker;
 
@@ -1332,9 +1475,9 @@ static void defer_alias_change_events(
     while ((marker = SVector_Foreach(&it))) {
         if (isAliasMarker(marker->marker_flags) &&
             /* The filter should contain `in` matcher for the alias. */
-            Selva_SubscriptionFilterMatch(ctx, node_id, marker)
+            Selva_SubscriptionFilterMatch(ctx, node, marker)
             ) {
-            marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CH_ALIAS);
+            marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_CH_ALIAS, node);
 
             /*
              * Wipe the markers of this subscription after the events have been
@@ -1350,7 +1493,7 @@ static void defer_alias_change_events(
  */
 static void field_change_precheck(
         RedisModuleCtx *ctx,
-        const Selva_NodeId node_id,
+        const struct SelvaModify_HierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers) {
     const unsigned short flags = SELVA_SUBSCRIPTION_FLAG_CH_FIELD;
 
@@ -1366,8 +1509,8 @@ static void field_change_precheck(
                  * We assume that SelvaSubscriptions_DeferFieldChangeEvents()
                  * is called before this function is called for another node.
                  */
-                memcpy(marker->filter_history.node_id, node_id, SELVA_NODE_ID_SIZE);
-                marker->filter_history.res = Selva_SubscriptionFilterMatch(ctx, node_id, marker);
+                SelvaHierarchy_GetNodeId(marker->filter_history.node_id, node);
+                marker->filter_history.res = Selva_SubscriptionFilterMatch(ctx, node, marker);
             }
         }
     }
@@ -1376,10 +1519,13 @@ static void field_change_precheck(
 void SelvaSubscriptions_FieldChangePrecheck(
         RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
-        const struct SelvaModify_HierarchyMetadata *metadata) {
+        const struct SelvaModify_HierarchyNode *node) {
+
+    const struct SelvaModify_HierarchyMetadata *metadata;
+    metadata = SelvaHierarchy_GetNodeMetadataByPtr(node);
+
     /* Detached markers. */
-    field_change_precheck(ctx, node_id, &hierarchy->subs.detached_markers);
+    field_change_precheck(ctx, node, &hierarchy->subs.detached_markers);
 
     if (!metadata) {
         fprintf(stderr, "%s:%d: Node metadata missing\n", __FILE__, __LINE__);
@@ -1387,13 +1533,13 @@ void SelvaSubscriptions_FieldChangePrecheck(
     }
 
     /* Markers on the node. */
-    field_change_precheck(ctx, node_id, &metadata->sub_markers);
+    field_change_precheck(ctx, node, &metadata->sub_markers);
 }
 
 static void defer_field_change_events(
         RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
+        const struct SelvaModify_HierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers,
         const char *field_str,
         size_t field_len) {
@@ -1406,13 +1552,17 @@ static void defer_field_change_events(
 
         SVector_ForeachBegin(&it, &sub_markers->vec);
         while ((marker = SVector_Foreach(&it))) {
+            Selva_NodeId node_id;
+
+            SelvaHierarchy_GetNodeId(node_id, node);
+
             if (((marker->marker_flags & flags) == flags) && !inhibitMarkerEvent(node_id, marker)) {
                 const int expressionMatchBefore = marker->filter_history.res && !memcmp(marker->filter_history.node_id, node_id, SELVA_NODE_ID_SIZE);
-                const int expressionMatchAfter = Selva_SubscriptionFilterMatch(ctx, node_id, marker);
+                const int expressionMatchAfter = Selva_SubscriptionFilterMatch(ctx, node, marker);
                 const int fieldsMatch = Selva_SubscriptionFieldMatch(marker, field_str, field_len);
 
                 if ((expressionMatchBefore && expressionMatchAfter && fieldsMatch) || (expressionMatchBefore ^ expressionMatchAfter)) {
-                    marker->marker_action(hierarchy, marker, flags);
+                    marker->marker_action(hierarchy, marker, flags, node);
                 }
             }
         }
@@ -1422,7 +1572,7 @@ static void defer_field_change_events(
 static void defer_array_field_change_events(
         RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
+        const struct SelvaModify_HierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers,
         const char *field_str,
         size_t field_len) {
@@ -1450,47 +1600,54 @@ static void defer_array_field_change_events(
             char path_field_str[path_field_len + 1];
 
             snprintf(path_field_str, path_field_len + 1, "%.*s[n]%s", (int)ary_field_len, field_str, path_field_start);
-            defer_field_change_events(ctx, hierarchy, node_id, sub_markers, path_field_str, path_field_len);
+            defer_field_change_events(ctx, hierarchy, node, sub_markers, path_field_str, path_field_len);
         }
 
         memcpy(ary_field_str, field_str, ary_field_len);
         ary_field_str[ary_field_len] = '\0';
         /* check for direct subscriptions on arrayField: true */
-        defer_field_change_events(ctx, hierarchy, node_id, sub_markers, ary_field_str, ary_field_len);
+        defer_field_change_events(ctx, hierarchy, node, sub_markers, ary_field_str, ary_field_len);
     }
 }
 
 void SelvaSubscriptions_DeferFieldChangeEvents(
         RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
-        const struct SelvaModify_HierarchyMetadata *metadata,
+        const struct SelvaModify_HierarchyNode *node,
         const char *field_str,
         size_t field_len) {
     if (strchr(field_str, '[')) {
         /* Array */
         /* Detached markers. */
-        defer_array_field_change_events(ctx, hierarchy, node_id, &hierarchy->subs.detached_markers, field_str, field_len);
+        defer_array_field_change_events(ctx, hierarchy, node, &hierarchy->subs.detached_markers, field_str, field_len);
 
-        if (!metadata) {
-            fprintf(stderr, "%s:%d: Node metadata missing\n", __FILE__, __LINE__);
+        /* RFE does this happen anymore? */
+        if (!node) {
+            fprintf(stderr, "%s:%d: Node pointer missing\n", __FILE__, __LINE__);
             return;
         }
 
+        const struct SelvaModify_HierarchyMetadata *metadata;
+        metadata = SelvaHierarchy_GetNodeMetadataByPtr(node);
+
         /* Markers on the node. */
-        defer_array_field_change_events(ctx, hierarchy, node_id, &metadata->sub_markers, field_str, field_len);
+        defer_array_field_change_events(ctx, hierarchy, node, &metadata->sub_markers, field_str, field_len);
     } else {
         /* Regular field */
         /* Detached markers. */
-        defer_field_change_events(ctx, hierarchy, node_id, &hierarchy->subs.detached_markers, field_str, field_len);
+        defer_field_change_events(ctx, hierarchy, node, &hierarchy->subs.detached_markers, field_str, field_len);
 
-        if (!metadata) {
-            fprintf(stderr, "%s:%d: Node metadata missing\n", __FILE__, __LINE__);
+        /* RFE does this happen anymore? */
+        if (!node) {
+            fprintf(stderr, "%s:%d: Node pointer missing\n", __FILE__, __LINE__);
             return;
         }
 
+        const struct SelvaModify_HierarchyMetadata *metadata;
+        metadata = SelvaHierarchy_GetNodeMetadataByPtr(node);
+
         /* Markers on the node. */
-        defer_field_change_events(ctx, hierarchy, node_id, &metadata->sub_markers, field_str, field_len);
+        defer_field_change_events(ctx, hierarchy, node, &metadata->sub_markers, field_str, field_len);
     }
 }
 
@@ -1545,7 +1702,7 @@ void Selva_Subscriptions_DeferAliasChangeEvents(
 void Selva_Subscriptions_DeferTriggerEvents(
         RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        Selva_NodeId node_id,
+        const struct SelvaModify_HierarchyNode *node,
         enum Selva_SubscriptionTriggerType event_type) {
     /* Trigger markers are always detached and have no node_id. */
     const struct Selva_SubscriptionMarkers *sub_markers = &hierarchy->subs.detached_markers;
@@ -1558,19 +1715,20 @@ void Selva_Subscriptions_DeferTriggerEvents(
         while ((marker = SVector_Foreach(&it))) {
             if (isTriggerMarker(marker->marker_flags) &&
                 marker->event_type == event_type &&
-                Selva_SubscriptionFilterMatch(ctx, node_id, marker)) {
+                Selva_SubscriptionFilterMatch(ctx, node, marker)) {
                 /*
                  * The node_id might be there already if the marker has a filter
                  * but trigger events will need the node_id there regardless of if
                  * a filter is actually used.
                  */
-                memcpy(marker->filter_history.node_id, node_id, SELVA_NODE_ID_SIZE);
+                SelvaHierarchy_GetNodeId(marker->filter_history.node_id, node);
 
                 /*
                  * We don't call defer_trigger_event() here directly to allow
                  * customization of subscription marker events.
+                 * Note that the node pointer is only valid during this function call.
                  */
-                marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_TRIGGER);
+                marker->marker_action(hierarchy, marker, SELVA_SUBSCRIPTION_FLAG_TRIGGER, node);
             }
         }
     }
@@ -2547,7 +2705,7 @@ int SelvaSubscriptions_DelMarkerCommand(RedisModuleCtx *ctx, RedisModuleString *
         return REDISMODULE_OK;
     }
 
-    err = SelvaSubscriptions_DeleteMarker(ctx, hierarchy, sub, marker_id);
+    err = delete_marker(ctx, hierarchy, sub, marker_id);
     if (err) {
         replyWithSelvaError(ctx, err);
     }

--- a/server/modules/selva/module/subscriptions.h
+++ b/server/modules/selva/module/subscriptions.h
@@ -291,8 +291,6 @@ int Selva_AddSubscriptionAliasMarker(
 /**
  * Add a subscription marker with a callback.
  * @param filter is an RPN expression used to determine if the callback should be called for this node.
- * @param dir_expression is an expression for SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION. The expression will be owned and managed by subscriptions and the called must not hold a pointer to it.
- * @param filter is an expression stored in the marker and it can be used by the callback. The expression will be owned and managed by subscriptions and the called must not hold a pointer to it.
  * @param callback is called each time all the marker conditions are met for a node.
  */
 int SelvaSubscriptions_AddCallbackMarker(
@@ -303,10 +301,11 @@ int SelvaSubscriptions_AddCallbackMarker(
         Selva_NodeId node_id,
         enum SelvaTraversal dir,
         const char *dir_field,
-        struct rpn_expression *dir_expression,
-        struct rpn_expression *filter,
+        const char *dir_expression_str,
+        const char *filter_str,
         Selva_SubscriptionMarkerAction *callback,
-        void *owner_ctx);
+        void *owner_ctx
+    );
 
 /**
  * Get a pointer to a subscription marker by subscription and marker id.

--- a/server/modules/selva/module/subscriptions.h
+++ b/server/modules/selva/module/subscriptions.h
@@ -119,7 +119,12 @@ enum Selva_SubscriptionTriggerType {
  * The action function must not hold a pointer to the node after the function
  * returns as the pointer is not guaranteed to be valid after the call.
  */
-typedef void Selva_SubscriptionMarkerAction(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags, const struct SelvaModify_HierarchyNode *node);
+typedef void Selva_SubscriptionMarkerAction(
+        struct RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        struct Selva_SubscriptionMarker *marker,
+        unsigned short event_flags,
+        const struct SelvaModify_HierarchyNode *node);
 
 /**
  * Subscription marker.
@@ -236,7 +241,7 @@ int SelvaSubscriptions_RefreshByMarkerId(
 int SelvaSubscriptions_Refresh(
         struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        Selva_SubscriptionId sub_id);
+        const Selva_SubscriptionId sub_id);
 
 /**
  * Refresh all subscriptions found in markers SVector.
@@ -260,7 +265,7 @@ void SelvaSubscriptions_Delete(
 int SelvaSubscriptions_DeleteMarker(
         struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        Selva_SubscriptionId sub_id,
+        const Selva_SubscriptionId sub_id,
         Selva_SubscriptionMarkerId marker_id);
 
 /**
@@ -335,6 +340,7 @@ void SelvaSubscriptions_DestroyDeferredEvents(struct SelvaModify_Hierarchy *hier
  * Inherit subscription markers from a parent to child nodes.
  */
 void SelvaSubscriptions_InheritParent(
+        struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         const Selva_NodeId node_id,
         struct SelvaModify_HierarchyMetadata *node_metadata,
@@ -346,6 +352,7 @@ void SelvaSubscriptions_InheritParent(
  * This function makes sense if there are markers traversing upwards.
  */
 void SelvaSubscriptions_InheritChild(
+        struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         const Selva_NodeId node_id,
         struct SelvaModify_HierarchyMetadata *node_metadata,
@@ -357,6 +364,7 @@ void SelvaSubscriptions_InheritChild(
  * @param field_str is a pointer to the name of the source field.
  */
 void SelvaSubscriptions_InheritEdge(
+        struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         struct SelvaModify_HierarchyNode *src_node,
         struct SelvaModify_HierarchyNode *dst_node,
@@ -373,6 +381,7 @@ void SelvaSubscriptions_DeferHierarchyEvents(
         struct SelvaModify_Hierarchy *hierarchy,
         const struct SelvaModify_HierarchyNode *node);
 void SelvaSubscriptions_DeferHierarchyDeletionEvents(
+        struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         const struct SelvaModify_HierarchyNode *node);
 void SelvaSubscriptions_FieldChangePrecheck(

--- a/server/modules/selva/module/subscriptions.h
+++ b/server/modules/selva/module/subscriptions.h
@@ -20,11 +20,15 @@
  *  make an early short-circuit to skip the matching logic even when the
  *  matcher flags would cause a check. These flags are never included in the
  *  flags_filters.
+ *  TODO Think about the naming of the flags.
+ *  TODO A dirty flag would be useful to tell whether a refresh is still needed and
+ *  if not the refresh could be skipped when attempted.
  */
 
 enum SelvaSubscriptionsMarkerFlags {
     /**
      * Marker cleared on a hierarchy change.
+     * The marker must be refreshed in order to keep receiving updates.
      */
     SELVA_SUBSCRIPTION_FLAG_CL_HIERARCHY = 0x0001,
 
@@ -44,8 +48,16 @@ enum SelvaSubscriptionsMarkerFlags {
      * Matches if an alias is moved or deleted.
      * This flag also acts a as modifier and it clears the markers of the
      * subscription after an event is deferred.
+     * The action function is called only if this flag is also set on the marker.
      */
     SELVA_SUBSCRIPTION_FLAG_CH_ALIAS = 0x0008,
+
+    /**
+     * Refresh marked this node.
+     * If this flag is set on the marker then the action function is called
+     * for each node that is marked on refresh.
+     */
+    SELVA_SUBSCRIPTION_FLAG_REFRESH = 0x0020,
 
     /**
      * Reference subscription.
@@ -81,20 +93,33 @@ struct SelvaModify_Hierarchy;
 struct SelvaModify_HierarchyCallback;
 struct SelvaModify_HierarchyMetadata;
 struct Selva_Subscription;
+struct Selva_SubscriptionMarker;
 struct hierarchy_subscriptions_tree;
 
+/**
+ * Trigger event types.
+ */
 enum Selva_SubscriptionTriggerType {
+    /**
+     * Node created.
+     */
     SELVA_SUBSCRIPTION_TRIGGER_TYPE_CREATED = 0,
+    /**
+     * Node updated.
+     */
     SELVA_SUBSCRIPTION_TRIGGER_TYPE_UPDATED,
+    /**
+     * Node deleted.
+     */
     SELVA_SUBSCRIPTION_TRIGGER_TYPE_DELETED,
 };
 
-struct Selva_SubscriptionMarker;
-
 /**
  * A callback that makes the actual defer action when a marker matches.
+ * The action function must not hold a pointer to the node after the function
+ * returns as the pointer is not guaranteed to be valid after the call.
  */
-typedef void Selva_SubscriptionMarkerAction(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags);
+typedef void Selva_SubscriptionMarkerAction(struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, unsigned short event_flags, const struct SelvaModify_HierarchyNode *node);
 
 /**
  * Subscription marker.
@@ -104,6 +129,10 @@ struct Selva_SubscriptionMarker {
     unsigned short marker_flags;
 
     Selva_SubscriptionMarkerAction *marker_action;
+    /**
+     * A pointer to optional data for the action to grab the required context.
+     */
+    void *marker_action_owner_ctx;
 
     enum SelvaTraversal dir;
     union {
@@ -178,23 +207,105 @@ int Selva_Subscriptions_InitHierarchy(struct SelvaModify_Hierarchy *hierarchy);
  */
 void SelvaSubscriptions_DestroyAll(struct RedisModuleCtx *ctx, struct SelvaModify_Hierarchy *hierarchy);
 
-int SelvaSubscriptions_TraverseMarker(struct RedisModuleCtx *ctx, struct SelvaModify_Hierarchy *hierarchy, struct Selva_SubscriptionMarker *marker, const struct SelvaModify_HierarchyCallback *cb);
-int SelvaSubscriptions_Refresh(struct RedisModuleCtx *ctx, struct SelvaModify_Hierarchy *hierarchy, Selva_SubscriptionId sub_id);
-void SelvaSubscriptions_RefreshByMarker(struct RedisModuleCtx *ctx, struct SelvaModify_Hierarchy *hierarchy, struct SVector *markers);
-void SelvaSubscriptions_Delete(struct RedisModuleCtx *ctx, struct SelvaModify_Hierarchy *hierarchy, Selva_SubscriptionId sub_id);
+/**
+ * Do a traversal over the given marker.
+ * Bear in mind that cb is passed directly to the hierarchy traversal, thus any
+ * filter set in the marker is not executed and the callback must execute the
+ * filter if required.
+ */
+int SelvaSubscriptions_TraverseMarker(
+        struct RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        struct Selva_SubscriptionMarker *marker,
+        const struct SelvaModify_HierarchyCallback *cb);
+
+/**
+ * Refresh a marker by id.
+ * Note that in contrary to other refresh functions this one will only traverse
+ * and refresh a single marker of the given subscription.
+ */
+int SelvaSubscriptions_RefreshByMarkerId(
+        struct RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        Selva_SubscriptionId sub_id,
+        Selva_SubscriptionMarkerId marker_id);
+
+/**
+ * Refresh all subscription markers of a given subscription id.
+ */
+int SelvaSubscriptions_Refresh(
+        struct RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        Selva_SubscriptionId sub_id);
+
+/**
+ * Refresh all subscriptions found in markers SVector.
+ */
+void SelvaSubscriptions_RefreshByMarker(
+        struct RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        struct SVector *markers);
+
+/**
+ * Delete a subsscription and all of its markers by subscription id.
+ */
+void SelvaSubscriptions_Delete(
+        struct RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        Selva_SubscriptionId sub_id);
 
 /**
  * Delete a single marker from a subscription.
  */
-int SelvaSubscriptions_DeleteMarker(struct RedisModuleCtx *ctx, struct SelvaModify_Hierarchy *hierarchy, struct Selva_Subscription *sub, Selva_SubscriptionMarkerId marker_id);
+int SelvaSubscriptions_DeleteMarker(
+        struct RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        Selva_SubscriptionId sub_id,
+        Selva_SubscriptionMarkerId marker_id);
 
+/**
+ * Delete a single marker from a subscription by a pointer to the marker.
+ */
+int SelvaSubscriptions_DeleteMarkerByPtr(
+        struct RedisModuleCtx *ctx,
+        struct SelvaModify_Hierarchy *hierarchy,
+        struct Selva_SubscriptionMarker *marker);
+
+/**
+ * Add a marker to a hierarchy alias.
+ * @param alias_name is a pointer to the alias name.
+ * @param node_id is the node the alias is currently pointing at.
+ */
 int Selva_AddSubscriptionAliasMarker(
         struct SelvaModify_Hierarchy *hierarchy,
         Selva_SubscriptionId sub_id,
         Selva_SubscriptionMarkerId marker_id,
         struct RedisModuleString *alias_name,
-        Selva_NodeId node_id
-    );
+        Selva_NodeId node_id);
+
+/**
+ * Add a subscription marker with a callback.
+ * @param filter is an RPN expression used to determine if the callback should be called for this node.
+ * @param dir_expression is an expression for SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION. The expression will be owned and managed by subscriptions and the called must not hold a pointer to it.
+ * @param filter is an expression stored in the marker and it can be used by the callback. The expression will be owned and managed by subscriptions and the called must not hold a pointer to it.
+ * @param callback is called each time all the marker conditions are met for a node.
+ */
+int SelvaSubscriptions_AddCallbackMarker(
+        struct SelvaModify_Hierarchy *hierarchy,
+        Selva_SubscriptionId sub_id,
+        Selva_SubscriptionMarkerId marker_id,
+        unsigned short marker_flags,
+        Selva_NodeId node_id,
+        enum SelvaTraversal dir,
+        const char *dir_field,
+        struct rpn_expression *dir_expression,
+        struct rpn_expression *filter,
+        Selva_SubscriptionMarkerAction *callback,
+        void *owner_ctx);
+
+/**
+ * Get a pointer to a subscription marker by subscription and marker id.
+ */
 struct Selva_SubscriptionMarker *SelvaSubscriptions_GetMarker(
         struct SelvaModify_Hierarchy *hierarchy,
         Selva_SubscriptionId sub_id,
@@ -210,26 +321,42 @@ void SelvaSubscriptions_ClearAllMarkers(
         struct SelvaModify_Hierarchy *hierarchy,
         struct SelvaModify_HierarchyNode *node);
 
+/**
+ * Test if the filter defined in the marker matches.
+ */
+int Selva_SubscriptionFilterMatch(struct RedisModuleCtx *ctx, const struct SelvaModify_HierarchyNode *node, struct Selva_SubscriptionMarker *marker);
+
+/**
+ * Destroy all deferred events.
+ */
 void SelvaSubscriptions_DestroyDeferredEvents(struct SelvaModify_Hierarchy *hierarchy);
 
+/**
+ * Inherit subscription markers from a parent to child nodes.
+ */
 void SelvaSubscriptions_InheritParent(
-        struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         const Selva_NodeId node_id,
         struct SelvaModify_HierarchyMetadata *node_metadata,
         size_t node_nr_children,
-        const Selva_NodeId parent_id,
-        struct SelvaModify_HierarchyMetadata *parent_metadata);
+        struct SelvaModify_HierarchyNode *parent);
+
+/**
+ * Inherit subscription markers from a child to parent nodes.
+ * This function makes sense if there are markers traversing upwards.
+ */
 void SelvaSubscriptions_InheritChild(
-        struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         const Selva_NodeId node_id,
         struct SelvaModify_HierarchyMetadata *node_metadata,
         size_t node_nr_parents,
-        const Selva_NodeId child_id,
-        struct SelvaModify_HierarchyMetadata *child_metadata);
+        struct SelvaModify_HierarchyNode *child);
+
+/**
+ * Inherit subscription markers over an edge field.
+ * @param field_str is a pointer to the name of the source field.
+ */
 void SelvaSubscriptions_InheritEdge(
-        struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
         struct SelvaModify_HierarchyNode *src_node,
         struct SelvaModify_HierarchyNode *dst_node,
@@ -244,22 +371,18 @@ void SelvaSubscriptions_DeferMissingAccessorEvents(struct SelvaModify_Hierarchy 
 void SelvaSubscriptions_DeferHierarchyEvents(
         struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
-        const struct SelvaModify_HierarchyMetadata *metadata);
+        const struct SelvaModify_HierarchyNode *node);
 void SelvaSubscriptions_DeferHierarchyDeletionEvents(
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
-        const struct SelvaModify_HierarchyMetadata *metadata);
+        const struct SelvaModify_HierarchyNode *node);
 void SelvaSubscriptions_FieldChangePrecheck(
         struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
-        const struct SelvaModify_HierarchyMetadata *metadata);
+        const struct SelvaModify_HierarchyNode *node);
 void SelvaSubscriptions_DeferFieldChangeEvents(
         struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        const Selva_NodeId node_id,
-        const struct SelvaModify_HierarchyMetadata *metadata,
+        const struct SelvaModify_HierarchyNode *node,
         const char *field_str,
         size_t field_len);
 void Selva_Subscriptions_DeferAliasChangeEvents(
@@ -269,7 +392,7 @@ void Selva_Subscriptions_DeferAliasChangeEvents(
 void Selva_Subscriptions_DeferTriggerEvents(
         struct RedisModuleCtx *ctx,
         struct SelvaModify_Hierarchy *hierarchy,
-        Selva_NodeId node_id,
+        const struct SelvaModify_HierarchyNode *node,
         enum Selva_SubscriptionTriggerType event_type);
 void SelvaSubscriptions_SendDeferredEvents(struct SelvaModify_Hierarchy *hierarchy);
 

--- a/server/modules/selva/test/edge-mock.c
+++ b/server/modules/selva/test/edge-mock.c
@@ -4,7 +4,7 @@
 #include "edge.h"
 #include "redismodule.h"
 
-struct EdgeField *Edge_GetField(struct SelvaModify_HierarchyNode *node __unused, const char *key_name_str __unused, size_t key_name_len __unused) {
+struct EdgeField *Edge_GetField(const struct SelvaModify_HierarchyNode *node __unused, const char *key_name_str __unused, size_t key_name_len __unused) {
     return NULL;
 }
 

--- a/server/modules/selva/test/hierarchy-mock.c
+++ b/server/modules/selva/test/hierarchy-mock.c
@@ -2,6 +2,6 @@
 #include "hierarchy.h"
 #include "errors.h"
 
-int SelvaHierarchy_IsNonEmptyField(struct SelvaModify_HierarchyNode *node __unused, const char *field_str __unused, size_t field_len __unused) {
+int SelvaHierarchy_IsNonEmptyField(const struct SelvaModify_HierarchyNode *node __unused, const char *field_str __unused, size_t field_len __unused) {
     return SELVA_ENOENT;
 }

--- a/server/modules/selva/test/subscriptions-mock.c
+++ b/server/modules/selva/test/subscriptions-mock.c
@@ -35,29 +35,24 @@ void SelvaSubscriptions_ClearAllMarkers(
 }
 
 void SelvaSubscriptions_InheritParent(
-        struct RedisModuleCtx *redis_ctx __unused,
         struct SelvaModify_Hierarchy *hierarchy __unused,
         const Selva_NodeId node_id __unused,
         struct SelvaModify_HierarchyMetadata *node_metadata __unused,
         size_t node_nr_children __unused,
-        const Selva_NodeId parent_id __unused,
-        struct SelvaModify_HierarchyMetadata *parent_metadata __unused) {
+        struct SelvaModify_HierarchyNode *parent __unused) {
     return;
 }
 
 void SelvaSubscriptions_InheritChild(
-        struct RedisModuleCtx *redis_ctx __unused,
         struct SelvaModify_Hierarchy *hierarchy __unused,
         const Selva_NodeId node_id __unused,
         struct SelvaModify_HierarchyMetadata *node_metadata __unused,
         size_t node_nr_parents __unused,
-        const Selva_NodeId child_id __unused,
-        struct SelvaModify_HierarchyMetadata *child_metadata __unused) {
+        struct SelvaModify_HierarchyNode *child) {
     return;
 }
 
 void SelvaSubscriptions_InheritEdge(
-        struct RedisModuleCtx *ctx __unused,
         struct SelvaModify_Hierarchy *hierarchy __unused,
         struct SelvaModify_HierarchyNode *src_node __unused,
         struct SelvaModify_HierarchyNode *dst_node __unused,
@@ -66,7 +61,17 @@ void SelvaSubscriptions_InheritEdge(
     return;
 }
 
-int SelvaSubscriptions_DeleteMarker(RedisModuleCtx *ctx __unused, SelvaModify_Hierarchy *hierarchy __unused, struct Selva_Subscription *sub __unused, Selva_SubscriptionMarkerId marker_id __unused) {
+int SelvaSubscriptions_DeleteMarker(
+        RedisModuleCtx *ctx __unused,
+        SelvaModify_Hierarchy *hierarchy __unused,
+        Selva_SubscriptionId sub_id __unused,
+        Selva_SubscriptionMarkerId marker_id __unused) {
+    return 0;
+}
+int SelvaSubscriptions_DeleteMarkerByPtr(
+        struct RedisModuleCtx *ctx __unused,
+        struct SelvaModify_Hierarchy *hierarchy __unused,
+        struct Selva_SubscriptionMarker *marker __unused) {
     return 0;
 }
 
@@ -77,8 +82,7 @@ void SelvaSubscriptions_DeferMissingAccessorEvents(struct SelvaModify_Hierarchy 
 void SelvaSubscriptions_DeferFieldChangeEvents(
         struct RedisModuleCtx *redis_ctx __unused,
         struct SelvaModify_Hierarchy *hierarchy __unused,
-        const Selva_NodeId node_id __unused,
-        const struct SelvaModify_HierarchyMetadata *metadata __unused,
+        const struct SelvaModify_HierarchyNode *node __unused,
         const char *field_str __unused,
         size_t field_len __unused) {
     return;
@@ -87,22 +91,20 @@ void SelvaSubscriptions_DeferFieldChangeEvents(
 void SelvaSubscriptions_DeferHierarchyEvents(
         struct RedisModuleCtx *ctx __unused,
         struct SelvaModify_Hierarchy *hierarchy __unused,
-        const Selva_NodeId node_id __unused,
-        const struct SelvaModify_HierarchyMetadata *metadata __unused) {
+        const struct SelvaModify_HierarchyNode *node __unused) {
     return;
 }
 
 void SelvaSubscriptions_DeferHierarchyDeletionEvents(
         struct SelvaModify_Hierarchy *hierarchy __unused,
-        const Selva_NodeId node_id __unused,
-        const struct SelvaModify_HierarchyMetadata *metadata __unused) {
+        const struct SelvaModify_HierarchyNode *node __unused) {
     return;
 }
 
 void Selva_Subscriptions_DeferTriggerEvents(
         struct RedisModuleCtx *redis_ctx __unused,
         struct SelvaModify_Hierarchy *hierarchy __unused,
-        Selva_NodeId node_id __unused,
+        const struct SelvaModify_HierarchyNode *node __unused,
         enum Selva_SubscriptionTriggerType event_type __unused) {
     return;
 }


### PR DESCRIPTION
- Pass a node pointer instead of node_id to majority of the funcs
- New `SELVA_SUBSCRIPTION_FLAG_REFRESH` flag
- Support markers with custom action functions
- Use const pointers whenever it's possible and makes sense
  semantically