### PR TITLE
Base64 encoding bug fixes

### DIFF
--- a/server/modules/selva/util/base64.c
+++ b/server/modules/selva/util/base64.c
@@ -12,7 +12,9 @@
 
 static const unsigned char base64_table[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-size_t base64_encode_s(unsigned char *out, const unsigned char *src, size_t len, size_t line_max) {
+size_t base64_encode_s(char *str_out, const char *str_in, size_t len, size_t line_max) {
+    const unsigned char *src = (const unsigned char *)str_in;
+    unsigned char *dst = (unsigned char *)str_out;
     unsigned char *pos;
     const unsigned char *end, *in;
     int line_len;
@@ -23,7 +25,7 @@ size_t base64_encode_s(unsigned char *out, const unsigned char *src, size_t len,
 
     end = src + len;
     in = src;
-    pos = out;
+    pos = dst;
     line_len = 0;
     while (end - in >= 3) {
         *pos++ = base64_table[in[0] >> 2];
@@ -51,18 +53,18 @@ size_t base64_encode_s(unsigned char *out, const unsigned char *src, size_t len,
         line_len += 4;
     }
 
-    if (line_len) {
+    if (line_len && line_max != SIZE_MAX) {
         *pos++ = '\n';
     }
 
     *pos = '\0';
-    return pos - out;
+    return pos - dst;
 }
 
-unsigned char * base64_encode(const unsigned char *src, size_t len, size_t *out_len)
+char * base64_encode(const char *str_in, size_t len, size_t *out_len)
 {
     const size_t line_max = 72;
-    unsigned char *out;
+    char *out;
     size_t n;
 
     out = RedisModule_Alloc(base64_out_len(len, line_max) + 1);
@@ -70,15 +72,16 @@ unsigned char * base64_encode(const unsigned char *src, size_t len, size_t *out_
         return NULL;
     }
 
-    n = base64_encode_s(out, src, len, line_max);
+    n = base64_encode_s(out, str_in, len, line_max);
     if (out_len) {
         *out_len = n;
     }
     return out;
 }
 
-unsigned char * base64_decode(const unsigned char *src, size_t len, size_t *out_len)
+char * base64_decode(const char *str_in, size_t len, size_t *out_len)
 {
+    const unsigned char *src = (const unsigned char *)str_in;
     unsigned char dtable[256], *out, *pos, block[4], tmp;
     size_t i, count, olen;
     int pad = 0;
@@ -139,5 +142,5 @@ unsigned char * base64_decode(const unsigned char *src, size_t len, size_t *out_
     }
 
     *out_len = pos - out;
-    return out;
+    return (char *)out;
 }

--- a/server/modules/selva/util/base64.h
+++ b/server/modules/selva/util/base64.h
@@ -2,45 +2,44 @@
 #ifndef BASE64_H
 #define BASE64_H
 
-size_t base64_encode_s(unsigned char *out, const unsigned char *src, size_t len, size_t line_max);
+size_t base64_encode_s(char *out, const char *str_in, size_t len, size_t line_max);
 
 /**
  * base64_encode - Base64 encode
- * @src: Data to be encoded
- * @len: Length of the data to be encoded
- * @out_len: Pointer to output length variable, or %NULL if not used
- * Returns: Allocated buffer of out_len bytes of encoded data,
- * or %NULL on failure
- *
  * Caller is responsible for freeing the returned buffer. Returned buffer is
  * nul terminated to make it easier to use as a C string. The nul terminator is
  * not included in out_len.
+ * @parma str_in Data to be encoded
+ * @param len Length of the data to be encoded
+ * @param out_len Pointer to output length variable, or %NULL if not used
+ * @returns Allocated buffer of out_len bytes of encoded data,
+ * or %NULL on failure
  */
-unsigned char * base64_encode(const unsigned char *src, size_t len, size_t *out_len);
+char * base64_encode(const char *str_in, size_t len, size_t *out_len);
 
 /**
  * Base64 decode.
  * Caller is responsible for freeing the returned buffer.
- * @param src Data to be decoded
+ * @param str_in Data to be decoded
  * @param len Length of the data to be decoded
  * @param out_len Pointer to output length variable
  * @returns Allocated buffer of out_len bytes of decoded data, or %NULL on failure
  */
-unsigned char * base64_decode(const unsigned char *src, size_t len, size_t *out_len);
+char * base64_decode(const char *str_in, size_t len, size_t *out_len);
 
 /**
  * Calculate the required buffer size of a string of n characters.
  * @param line_max is the max line length. 0 = no limit; 72 = typical.
  */
 static size_t base64_out_len(size_t n, size_t line_max) {
-    /* RFE Techincally this should be ok but with shorted padding */
-#if 0
-    return ((4 * n / 3) + 3) & ~3;
-#endif
     size_t olen;
 
+    /* This version would be with padding but we don't pad */
+#if 0
     olen = n * 4 / 3 + 4; /* 3-byte blocks to 4-byte */
-    olen += olen / line_max; /* line feeds */
+#endif
+    olen = ((4 * n / 3) + 3) & ~3;
+    olen += line_max > 0 ? olen / line_max : 0; /* line feeds */
 
     return olen;
 }


### PR DESCRIPTION
- Handle strings as signed externally (Intel C)
- Fix base64_out_len() for line_max=0
- Calc base64 length without padding
- Don't add linefeed to the base64 output if line_max == 0