### PR TITLE
Should fix rest of the missing fields when using $all: true

### DIFF
--- a/client/src/get/executeGetOperations/find.ts
+++ b/client/src/get/executeGetOperations/find.ts
@@ -90,8 +90,9 @@ function parseGetOpts(
         mapping[path].default = $default
       }
     } else if (path === '' && k === '$all') {
-      fields = new Set(['*'])
-      hasAll = true
+      // fields = new Set(['*'])
+      fields.add('*')
+      // hasAll = true
     } else if (k === '$all') {
       if (!mapping[path]) {
         mapping[path] = { maybeReferenceAll: true }

--- a/client/test/reference.ts
+++ b/client/test/reference.ts
@@ -523,6 +523,7 @@ test.serial('list of simple singular reference', async (t) => {
     children: {
       id: true,
       title: true,
+      parents: true,
       specialMatch: {
         id: true,
         title: true,
@@ -541,22 +542,24 @@ test.serial('list of simple singular reference', async (t) => {
     },
   })
 
-  t.deepEqualIgnoreOrder(result, {
+  t.deepEqual(result, {
     children: [
       {
         id: 'clA',
         title: 'yesh club',
+        parents: ['root'],
         specialMatch: { id: 'maA', title: 'yesh match' },
       },
     ],
   })
 
-  t.deepEqualIgnoreOrder(
+  t.deepEqual(
     await client.get({
       $id: 'root',
       $language: 'en',
       children: {
         $all: true,
+        parents: true,
         specialMatch: {
           id: true,
           title: true,
@@ -579,6 +582,7 @@ test.serial('list of simple singular reference', async (t) => {
         {
           id: 'clA',
           type: 'club',
+          parents: ['root'],
           title: 'yesh club',
           specialMatch: { id: 'maA', title: 'yesh match' },
         },


### PR DESCRIPTION
All tests that use $all should pass, including the new cases I added that we noticed were missing some fields