### PR TITLE
Don't fail when alias query is empty

### DIFF
--- a/server/modules/selva/module.c
+++ b/server/modules/selva/module.c
@@ -127,6 +127,10 @@ static void RedisModuleString2Selva_NodeId(Selva_NodeId nodeId, const RedisModul
 static const char *sztok(const char *s, size_t size, size_t * restrict i) {
     const char *r = NULL;
 
+    if (size == 0) {
+        return NULL;
+    }
+
     if (*i < size - 1) {
         r = s + *i;
         *i = *i + strnlen(r, size) + 1;


### PR DESCRIPTION
sztok() should break if size == 0.