### PR TITLE
Optimize order item usage

### DIFF
--- a/server/modules/selva/module/aggregate.c
+++ b/server/modules/selva/module/aggregate.c
@@ -391,20 +391,22 @@ static size_t AggregateCommand_AggregateOrderedResult(
      */
     SVector_ForeachBegin(&it, order_result);
     while ((item = SVector_Foreach(&it))) {
+        struct SelvaModify_HierarchyNode *node = item->node;
         int err;
+
         if (limit-- == 0) {
             break;
         }
 
-        struct SelvaModify_HierarchyNode *node;
-
-        /* TODO Consider if having hierarchy node pointers here would be better. */
-        node = SelvaHierarchy_FindNode(hierarchy, item->id);
-        err = apply_agg_fn(node, args);
+        if (node) {
+            err = apply_agg_fn(node, args);
+        } else {
+            err = SELVA_HIERARCHY_ENOENT;
+        }
         if (err) {
             fprintf(stderr, "%s:%d: Failed to handle field(s) of the node: \"%.*s\" err: %s\n",
                     __FILE__, __LINE__,
-                    (int)SELVA_NODE_ID_SIZE, item->id,
+                    (int)SELVA_NODE_ID_SIZE, item->node_id,
                     getSelvaErrorStr(err));
             continue;
         }
@@ -457,7 +459,7 @@ static size_t AggregateCommand_AggregateOrderedArrayResult(
             RedisModule_ReplyWithNull(ctx);
             fprintf(stderr, "%s:%d: Failed to handle field(s) of the node: \"%.*s\" err: %s\n",
                     __FILE__, __LINE__,
-                    (int)SELVA_NODE_ID_SIZE, item->id,
+                    (int)SELVA_NODE_ID_SIZE, item->node_id,
                     getSelvaErrorStr(err));
         }
 

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -1120,26 +1120,24 @@ static size_t FindCommand_PrintOrderedResult(
         }
 
         if (merge_strategy != MERGE_STRATEGY_NONE) {
-            err = send_node_object_merge(ctx, lang, item->id, merge_strategy, merge_path, fields, nr_fields_out);
+            err = send_node_object_merge(ctx, lang, item->node_id, merge_strategy, merge_path, fields, nr_fields_out);
         } else if (fields) {
-            struct SelvaModify_HierarchyNode *node;
+            struct SelvaModify_HierarchyNode *node = item->node;
 
-            /* TODO Consider if having hierarchy node pointers here would be better. */
-            node = SelvaHierarchy_FindNode(hierarchy, item->id);
             if (node) {
                 err = send_node_fields(ctx, lang, hierarchy, node, fields);
             } else {
                 err = SELVA_HIERARCHY_ENOENT;
             }
         } else {
-            RedisModule_ReplyWithStringBuffer(ctx, item->id, Selva_NodeIdLen(item->id));
+            RedisModule_ReplyWithStringBuffer(ctx, item->node_id, Selva_NodeIdLen(item->node_id));
             err = 0;
         }
         if (err) {
             RedisModule_ReplyWithNull(ctx);
             fprintf(stderr, "%s:%d: Failed to handle field(s) of the node: \"%.*s\" err: %s\n",
                     __FILE__, __LINE__,
-                    (int)SELVA_NODE_ID_SIZE, item->id,
+                    (int)SELVA_NODE_ID_SIZE, item->node_id,
                     getSelvaErrorStr(err));
         }
 
@@ -1188,7 +1186,7 @@ static size_t FindCommand_PrintOrderedArrayResult(
             RedisModule_ReplyWithNull(ctx);
             fprintf(stderr, "%s:%d: Failed to handle field(s) of the node: \"%.*s\" err: %s\n",
                     __FILE__, __LINE__,
-                    (int)SELVA_NODE_ID_SIZE, item->id,
+                    (int)SELVA_NODE_ID_SIZE, item->node_id,
                     getSelvaErrorStr(err));
         }
 

--- a/server/modules/selva/module/traversal.c
+++ b/server/modules/selva/module/traversal.c
@@ -282,7 +282,7 @@ int SelvaTraversal_CompareAsc(const void ** restrict a_raw, const void ** restri
         }
     }
 
-    return memcmp(a->id, b->id, SELVA_NODE_ID_SIZE);
+    return memcmp(a->node_id, b->node_id, SELVA_NODE_ID_SIZE);
 }
 
 int SelvaTraversal_CompareDesc(const void ** restrict a_raw, const void ** restrict b_raw) {
@@ -417,8 +417,9 @@ struct TraversalOrderedItem *SelvaTraversal_CreateOrderItem(
         return NULL;
     }
 
-    memcpy(item->id, nodeId, SELVA_NODE_ID_SIZE);
     item->type = type;
+    memcpy(item->node_id, nodeId, SELVA_NODE_ID_SIZE);
+    item->node = node;
     if (type == ORDERED_ITEM_TYPE_TEXT && data_len > 0) {
         strxfrm_l(item->data, data, final_data_len + 1, locale);
     }
@@ -533,8 +534,9 @@ struct TraversalOrderedItem *SelvaTraversal_CreateObjectBasedOrderItem(
         return NULL;
     }
 
-    memcpy(item->id, EMPTY_NODE_ID, SELVA_NODE_ID_SIZE);
     item->type = type;
+    memcpy(item->node_id, EMPTY_NODE_ID, SELVA_NODE_ID_SIZE);
+    item->node = NULL;
     if (type == ORDERED_ITEM_TYPE_TEXT && data_len > 0) {
         strxfrm_l(item->data, data, final_data_len + 1, locale);
     }

--- a/server/modules/selva/module/traversal.h
+++ b/server/modules/selva/module/traversal.h
@@ -45,8 +45,9 @@ enum TraversalOrderedItemType {
 };
 
 struct TraversalOrderedItem {
-    Selva_NodeId id;
     enum TraversalOrderedItemType type;
+    Selva_NodeId node_id;
+    struct SelvaModify_HierarchyNode *node;
     struct SelvaObject *data_obj;
     double d;
     size_t data_len;


### PR DESCRIPTION
If we store a pointer to the node when creating an ordered item
we can avoid the lookup later on when the query results are sent
to the client.