### PR TITLE
Optimize node type filtering

### DIFF
--- a/server/modules/selva/include/selva.h
+++ b/server/modules/selva/include/selva.h
@@ -87,7 +87,14 @@ static inline void Selva_NodeIdCpy(Selva_NodeId dest, const char *src) {
  * Compare node types.
  */
 static inline int Selva_CmpNodeType(const char t1[SELVA_NODE_TYPE_SIZE], const char t2[SELVA_NODE_TYPE_SIZE]) {
-    return !(*(unsigned short *)t1 ^ *(unsigned short *)t2);
+    unsigned short a, b;
+
+    _Static_assert(SELVA_NODE_TYPE_SIZE == sizeof(a), "type size matches the cmp variable");
+
+    memcpy(&a, t1, SELVA_NODE_TYPE_SIZE);
+    memcpy(&b, t2, SELVA_NODE_TYPE_SIZE);
+
+    return a ^ b;
 }
 
 /**

--- a/server/modules/selva/module/rpn.c
+++ b/server/modules/selva/module/rpn.c
@@ -1057,9 +1057,8 @@ static enum rpn_error rpn_op_cidcmp(struct RedisModuleCtx *redis_ctx __unused, s
     /*
      * Note the the allocated string is always large enough,
      * so the comparison is safe.
-     * TODO Could use Selva_CmpNodeType() here
      */
-    return push_int_result(ctx, !memcmp(OPERAND_GET_S(a), OPERAND_GET_S(ctx->reg[0]), SELVA_NODE_TYPE_SIZE));
+    return push_int_result(ctx, !Selva_CmpNodeType(OPERAND_GET_S(a), OPERAND_GET_S(ctx->reg[0])));
 }
 
 static enum rpn_error rpn_op_getsfld(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ctx) {


### PR DESCRIPTION
Instead of branching to memcmp() we can inline a faster check.