### PR TITLE
Simplify numeric array parsing

### DIFF
--- a/client/src/get/executeGetOperations/index.ts
+++ b/client/src/get/executeGetOperations/index.ts
@@ -313,23 +313,14 @@ export const TYPE_CASTS: Record<
 
     return Array.isArray(r) ? r[0] : r
   },
-  // array: (x: any) => JSON.parse(x),
   array: (x: any, id: string, field: string, schema, lang) => {
     const fieldSchema = <FieldSchemaArrayLike>getNestedSchema(schema, id, field)
     if (!fieldSchema || !fieldSchema.items) {
       return x
     }
 
-    if (['int', 'float', 'number'].includes(fieldSchema.items.type)) {
-      const converted = x.map((num) => {
-        if (typeof num === 'string') {
-          return Number(num)
-        } else {
-          return num
-        }
-      })
-
-      return converted
+    if (['float', 'number'].includes(fieldSchema.items.type)) {
+      return x.map(Number)
     } else if (
       ['object', 'record'].includes(fieldSchema.items.type) ||
       (!lang && fieldSchema.items.type === 'text')

--- a/client/test/getBasic.ts
+++ b/client/test/getBasic.ts
@@ -118,6 +118,7 @@ test.beforeEach(async (t) => {
           dingdongs: { type: 'array', items: { type: 'string' } },
           floatArray: { type: 'array', items: { type: 'float' } },
           intArray: { type: 'array', items: { type: 'int' } },
+          tsArray: { type: 'array', items: { type: 'timestamp' } },
           refs: { type: 'references' },
           value: { type: 'number' },
           age: { type: 'number' },
@@ -2322,6 +2323,7 @@ test.serial('get - field with array', async (t) => {
     dingdongs: ['a', 'b', 'test'],
     intArray: [1, 2, 3, 4, 5],
     floatArray: [1.1, 2.2, 3.3, 4.4],
+    tsArray: [ 1634032349768, 1634032355278 ],
     objRec: {
       abba: {
         intArray: [1, 2, 3, 4, 5],
@@ -2384,6 +2386,7 @@ test.serial('get - field with array', async (t) => {
     intArray: true,
     floatArray: true,
     objArray: true,
+    tsArray: true,
     objRec: true,
   })
 
@@ -2393,6 +2396,7 @@ test.serial('get - field with array', async (t) => {
     dingdongs: ['a', 'b', 'test'],
     intArray: [1, 2, 3, 4, 5],
     floatArray: [1.1, 2.2, 3.3, 4.4],
+    tsArray: [ 1634032349768, 1634032355278 ],
     objRec: {
       abba: {
         intArray: [1, 2, 3, 4, 5],
@@ -2427,6 +2431,7 @@ test.serial('get - field with array', async (t) => {
     dingdongs: ['a', 'b', 'test'],
     intArray: [1, 2, 3, 4, 5],
     floatArray: [1.1, 2.2, 3.3, 4.4],
+    tsArray: [ 1634032349768, 1634032355278 ],
     objRec: {
       abba: {
         intArray: [1, 2, 3, 4, 5],


### PR DESCRIPTION
Integers are always already parsed by redis-parser and floats
are always returned as strings.