### PR TITLE
Optimize SVector memory usage

### DIFF
--- a/server/modules/selva/util/mempool.c
+++ b/server/modules/selva/util/mempool.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 #include <sys/mman.h>
 #include "mempool.h"

--- a/server/modules/selva/util/mempool.h
+++ b/server/modules/selva/util/mempool.h
@@ -2,7 +2,6 @@
 #ifndef _UTIL_MEMPOOL_H_
 #define _UTIL_MEMPOOL_H_
 
-#include <stdint.h>
 #include "cdefs.h"
 #include "queue.h"
 

--- a/server/modules/selva/util/svector.c
+++ b/server/modules/selva/util/svector.c
@@ -571,7 +571,7 @@ void *SVector_Shift(SVector * restrict vec) {
         assert(vec->vec_last <= vec->vec_arr_len);
         assert(vec->vec_arr_shift_index <= vec->vec_last);
 
-        if (vec->vec_arr_shift_index > vec->vec_last / 2) {
+        if (vec->vec_arr_shift_index == _SVECTOR_SHIFT_RESET_THRESHOLD) {
             SVector_ShiftReset(vec);
         }
 
@@ -624,10 +624,6 @@ void SVector_ShiftReset(SVector * restrict vec) {
         return;
     }
 
-    /*
-     * We assume that nobody will call this function when nothing was
-     * actually inserted, thus no need to check if vec_arr is NULL.
-     */
     vec->vec_last -= vec->vec_arr_shift_index;
     memmove(vec->vec_arr, vec->vec_arr + vec->vec_arr_shift_index, VEC_SIZE(vec->vec_last));
     vec->vec_arr_shift_index = 0;


### PR DESCRIPTION
We can squeeze 8 bytes from every SVector if we pack the numeric
struct fields and use the optimum number of bits for shifting and
SVector mode.