### PR TITLE
Fix casting object fields in an array with $list

### DIFF
--- a/client/src/get/executeGetOperations/find.ts
+++ b/client/src/get/executeGetOperations/find.ts
@@ -14,7 +14,7 @@ import {
   sourceFieldToDir,
   addMarker,
 } from './'
-import { padId, joinIds } from '../utils'
+import { padId, joinIds, EMPTY_ID } from '../utils'
 import { setNestedResult, getNestedSchema } from '../utils'
 import { makeLangArg } from './util'
 import { mkIndex } from './indexing'
@@ -763,9 +763,10 @@ const executeFindOperation = async (
 
       const mapping = fieldMapping[field]
       const targetField = mapping?.targetField
-      const casted = id
-        ? typeCast(value, id, field, schema, lang)
-        : typeCast(value, op.id, `${op.field}[0].${field}`, schema, lang)
+      const casted =
+        id === EMPTY_ID
+          ? typeCast(value, op.id, `${op.field}[0].${field}`, schema, lang)
+          : typeCast(value, id, field, schema, lang)
 
       if (targetField) {
         for (const f of targetField) {

--- a/client/src/get/utils.ts
+++ b/client/src/get/utils.ts
@@ -156,3 +156,5 @@ export const setNestedResult = (
 
 export const joinIds = (ids: string[]): string =>
   ids.map((id) => padId(id)).join('')
+
+export const EMPTY_ID = '\0'.repeat(10)

--- a/client/test/getBasic.ts
+++ b/client/test/getBasic.ts
@@ -2314,7 +2314,7 @@ test.serial('get - record with nested wildcard query', async (t) => {
   await client.destroy()
 })
 
-test.serial.only('get - field with array', async (t) => {
+test.serial('get - field with array', async (t) => {
   const client = connect({ port })
   const id = await client.set({
     type: 'lekkerType',


### PR DESCRIPTION
Consider a node with following fields:

```
{
  o: {
    arr: [ { v: 1.1, name: 'a' }, { v: 1.2, name: 'b' } ]
  }
}
```

If  the field `o.arr` is queried with a `$list` attribute then
the values selected don't go through type casting.