### PR TITLE
Get SelvaObject type and value on a single op

### DIFF
--- a/server/modules/selva/module/rpn.c
+++ b/server/modules/selva/module/rpn.c
@@ -691,7 +691,7 @@ static enum rpn_error rpn_getfld(struct RedisModuleCtx *redis_ctx, struct rpn_ct
     struct SelvaObject *obj;
     const char *field_str = OPERAND_GET_S(field);
     const size_t field_len = OPERAND_GET_S_LEN(field);
-    RedisModuleString *value = NULL;
+    struct SelvaObjectAny any;
     int err;
 
     obj = open_object(redis_ctx, ctx);
@@ -702,43 +702,33 @@ static enum rpn_error rpn_getfld(struct RedisModuleCtx *redis_ctx, struct rpn_ct
         return RPN_ERR_NPE;
     }
 
-    const enum SelvaObjectType field_type = SelvaObject_GetTypeStr(obj, field_str, field_len);
-    if (field_type == SELVA_OBJECT_NULL) {
-        return (type == RPN_LVTYPE_NUMBER) ? push_double_result(ctx, nan_undefined()) : push_empty_value(ctx);
-    } else if (field_type == SELVA_OBJECT_SET) {
-        struct SelvaSet *set;
+    err = SelvaObject_GetAnyStr(obj, field_str, field_len, &any);
+    if (err || any.type == SELVA_OBJECT_NULL) {
+        if (err == SELVA_ENOENT) {
+            return (type == RPN_LVTYPE_NUMBER) ? push_double_result(ctx, nan_undefined()) : push_empty_value(ctx);
+        }
+        return RPN_ERR_ENOMEM; /* Presumably this the only other relevant error. */
+    }
 
-        set = SelvaObject_GetSetStr(obj, field_str, field_len);
-        if (!set) {
+    const enum SelvaObjectType field_type = any.type;
+    if (field_type == SELVA_OBJECT_SET) {
+        if (likely(any.set)) {
+            /*
+             * We don't need to care about the type of the set yet because all the
+             * future operations are typesafe anyway.
+             */
+            return push_selva_set_result(ctx, any.set);
+        } else {
+            /* RFE Should we return nan_undefined() for RPN_LVTYPE_NUMBER */
             return push_empty_value(ctx);
         }
-
-        /*
-         * We don't need to care about the type of the set yet because all the
-         * future operations are typesafe anyway.
-         */
-        return push_selva_set_result(ctx, set);
     } else { /* Primitive type */
         if (type == RPN_LVTYPE_NUMBER) {
-            double dvalue;
-
-            switch (field_type) {
-            case SELVA_OBJECT_DOUBLE:
-                err = SelvaObject_GetDoubleStr(obj, field_str, field_len, &dvalue);
-                break;
-            case SELVA_OBJECT_LONGLONG:
-                {
-                    long long v;
-
-                    err = SelvaObject_GetLongLongStr(obj, field_str, field_len, &v);
-                    dvalue = (double)v;
-                }
-                break;
-            default:
-                err = RPN_ERR_NAN;
-            }
-
-            if (err) {
+            if (field_type == SELVA_OBJECT_DOUBLE) {
+                return push_double_result(ctx, any.d);
+            } else if (field_type == SELVA_OBJECT_LONGLONG) {
+                return push_double_result(ctx, (double)any.ll);
+            } else {
                 const char *type_str = SelvaObject_Type2String(field_type, NULL);
 
                 fprintf(stderr, "%s:%d: Field value [%.*s].%.*s is not a number, actual type: \"%s\"\n",
@@ -749,27 +739,19 @@ static enum rpn_error rpn_getfld(struct RedisModuleCtx *redis_ctx, struct rpn_ct
 
                 return RPN_ERR_NAN;
             }
-
-            return push_double_result(ctx, dvalue);
-        } else { /* Assume SELVA_OBJECT_STRING && RPN_LVTYPE_STRING */
-            /* This will fail if the field type is not a string. */
-            /* TODO: wrap this in a new function so it takes lang and gets from text if it's a text type object instead of string inn rms_field */
-            err = SelvaObject_GetStringStr(obj, field_str, field_len, &value);
-            if (err || !value) {
+        } else { /* Assume RPN_LVTYPE_STRING */
+            /* TODO: Add lang support */
+            if (field_type == SELVA_OBJECT_STRING && any.str) {
+                return push_rm_string_result(ctx, any.str);
+            } else {
 #if 0
-                fprintf(stderr, "%s:%d: Field \"%s\" not found for node: \"%.*s\"\n",
+                fprintf(stderr, "%s:%d: Field \"%s\" not found in node: \"%.*s\"\n",
                         __FILE__, __LINE__,
                         OPERAND_GET_S(field),
                         (int)SELVA_NODE_ID_SIZE, (const void *)OPERAND_GET_S(ctx->reg[0]));
 #endif
                 return push_empty_value(ctx);
             }
-
-            /*
-             * Supposedly there is no need to free `value`
-             * because we are using automatic memory management.
-             */
-            return push_rm_string_result(ctx, value);
         }
     }
 }

--- a/server/modules/selva/module/selva_object.c
+++ b/server/modules/selva/module/selva_object.c
@@ -1525,6 +1525,57 @@ int SelvaObject_GetPointerPartialMatchStr(struct SelvaObject *obj, const char *k
     return off;
 }
 
+int SelvaObject_GetAnyStr(struct SelvaObject *obj, const char *key_name_str, size_t key_name_len, struct SelvaObjectAny *res) {
+    struct SelvaObjectKey *key;
+    enum SelvaObjectType type;
+    int err;
+
+    err = get_key(obj, key_name_str, key_name_len, 0, &key);
+    if (err) {
+        return err;
+    }
+
+    res->subtype = key->subtype;
+    res->user_meta = key->user_meta;
+    type = key->type;
+    res->type = type;
+
+    switch (type) {
+    case SELVA_OBJECT_NULL:
+        res->p = NULL;
+        break;
+    case SELVA_OBJECT_DOUBLE:
+        res->d = key->emb_double_value;
+        break;
+    case SELVA_OBJECT_LONGLONG:
+        res->ll = key->emb_ll_value;
+        break;
+    case SELVA_OBJECT_STRING:
+        res->str = key->value;
+        break;
+    case SELVA_OBJECT_OBJECT:
+        res->obj = key->value;
+        break;
+    case SELVA_OBJECT_SET:
+        res->set = &key->selva_set;
+        break;
+    case SELVA_OBJECT_ARRAY:
+        res->array = key->array;
+        break;
+    case SELVA_OBJECT_POINTER:
+        res->p = key->value;
+        break;
+    }
+
+    return 0;
+}
+
+int SelvaObject_GetAny(struct SelvaObject *obj, const RedisModuleString *key_name, struct SelvaObjectAny *res) {
+    TO_STR(key_name);
+
+    return SelvaObject_GetAnyStr(obj, key_name_str, key_name_len, res);
+}
+
 enum SelvaObjectType SelvaObject_GetTypeStr(struct SelvaObject *obj, const char *key_name_str, size_t key_name_len) {
     struct SelvaObjectKey *key;
     enum SelvaObjectType type = SELVA_OBJECT_NULL;

--- a/server/modules/selva/module/selva_object.h
+++ b/server/modules/selva/module/selva_object.h
@@ -90,6 +90,21 @@ struct SelvaObjectPointerOpts {
  */
 #define selvaobject_autofree __attribute__((cleanup(_cleanup_SelvaObject_Destroy)))
 
+struct SelvaObjectAny {
+    enum SelvaObjectType type; /*!< Type of the value. */
+    enum SelvaObjectType subtype; /*!< Subtype of the value. Arrays use this. */
+    SelvaObjectMeta_t user_meta; /*!< User defined metadata. */
+    union {
+        double d; /*!< SELVA_OBJECT_DOUBLE */
+        long long ll; /*!< SELVA_OBJECT_LONGLONG */
+        struct RedisModuleString *str; /* SELVA_OBJECT_STRING */
+        struct SelvaObject *obj; /* SELVA_OBJECT_OBJECT */
+        struct SelvaSet *set; /*!< SELVA_OBJECT_SET */
+        struct SVector *array; /*!< SELVA_OBJECT_ARRAY */
+        void *p; /* SELVA_OBJECT_POINTER */
+    };
+};
+
 /**
  * Create a new SelvaObject.
  * @return Returns a pointer to the newly created object;
@@ -208,6 +223,9 @@ int SelvaObject_SetPointer(struct SelvaObject *obj, const struct RedisModuleStri
 int SelvaObject_GetPointerStr(struct SelvaObject *obj, const char *key_name_str, size_t key_name_len, void **out_p);
 int SelvaObject_GetPointer(struct SelvaObject *obj, const struct RedisModuleString *key_name, void **out_p);
 int SelvaObject_GetPointerPartialMatchStr(struct SelvaObject *obj, const char *key_name_str, size_t key_name_len, void **out_p);
+
+int SelvaObject_GetAnyStr(struct SelvaObject *obj, const char *key_name_str, size_t key_name_len, struct SelvaObjectAny *res);
+int SelvaObject_GetAny(struct SelvaObject *obj, const struct RedisModuleString *key_name, struct SelvaObjectAny *res);
 
 enum SelvaObjectType SelvaObject_GetTypeStr(struct SelvaObject *obj, const char *key_name_str, size_t key_name_len);
 enum SelvaObjectType SelvaObject_GetType(struct SelvaObject *obj, const struct RedisModuleString *key_name);


### PR DESCRIPTION
This makes the RPN execution slightly cheaper when a lot of field values are needed for evaluation. Although, the speedup isn't as extreme as one could think at first, because only the first `get_key()` is expensive as the `SelvaObject` is not in cache yet.