### PR TITLE
Simplify RDB encver handling

### DIFF
--- a/server/modules/selva/module/edge.c
+++ b/server/modules/selva/module/edge.c
@@ -692,7 +692,7 @@ struct EdgeField_load_data {
  *   dst_id
  * ]
  */
-static void *EdgeField_RdbLoad(struct RedisModuleIO *io, __unused int encver, void *p) {
+static void *EdgeField_RdbLoad(struct RedisModuleIO *io, __unused int encver __unused, void *p) {
     RedisModuleCtx *ctx = RedisModule_GetContextFromIO(io);
     struct EdgeField_load_data *load_data = (struct EdgeField_load_data *)p;
     struct SelvaModify_Hierarchy *hierarchy = load_data->hierarchy;
@@ -703,7 +703,6 @@ static void *EdgeField_RdbLoad(struct RedisModuleIO *io, __unused int encver, vo
     struct EdgeField *edge_field;
 
     constraint_id = RedisModule_LoadUnsigned(io);
-
     if (constraint_id == EDGE_FIELD_CONSTRAINT_DYNAMIC) {
         char *node_type __auto_free = NULL;
         char *field_name_str __auto_free = NULL;
@@ -759,10 +758,6 @@ static void *EdgeField_RdbLoad(struct RedisModuleIO *io, __unused int encver, vo
 
 int Edge_RdbLoad(struct RedisModuleIO *io, int encver, SelvaModify_Hierarchy *hierarchy, struct SelvaModify_HierarchyNode *node) {
     RedisModuleCtx *ctx = RedisModule_GetContextFromIO(io);
-
-    if (encver < 1) { /* hierarchy encver */
-        return 0; /* Only the latest version supports loading metadata. */
-    }
 
     if (unlikely(!ctx)) {
         RedisModule_LogIOError(io, "warning", "Redis ctx can't be NULL");

--- a/server/modules/selva/module/selva_object.c
+++ b/server/modules/selva/module/selva_object.c
@@ -14,7 +14,6 @@
 #include "tree.h"
 #include "selva_object.h"
 
-#define SELVA_OBJECT_ENCODING_VERSION   0 /*!< Encoding version for RDB serialization. */
 #define SELVA_OBJECT_KEY_MAX            USHRT_MAX /*!< Maximum length of a key including dots and array notation. */
 #define SELVA_OBJECT_SIZE_MAX           (1 << 30) /*!< Maximum number of keys in a SelvaObject. */
 


### PR DESCRIPTION
With the latest changes to the node storage model only the latest
encoding version is supported, so we can make things a bit simpler.