### PR TITLE
Fix inserting node_id multiple times as an adj

### DIFF
--- a/client/test/rdb.ts
+++ b/client/test/rdb.ts
@@ -187,6 +187,30 @@ test.serial('can reload from RDB', async (t) => {
     }
   })
 
+  await client.set({
+    $id: 'viTest',
+    title: { en: 'hello' },
+    stringAry: ['hello', 'world'],
+    doubleAry: [1.0, 2.1, 3.2],
+    intAry: [7, 6, 5, 4, 3, 2, 999],
+    children: [
+      {
+        type: 'lekkerType',
+        title: { en: 'hello' },
+        children: [
+          {
+            type: 'lekkerType',
+            title: { en: 'hello' },
+          },
+          {
+            type: 'lekkerType',
+            title: { en: 'hallo' },
+          },
+        ]
+      }
+    ]
+  })
+
   await client.redis.save()
   await wait(1000)
   await restartServer()

--- a/server/modules/selva/module/hierarchy.c
+++ b/server/modules/selva/module/hierarchy.c
@@ -2276,6 +2276,9 @@ void *HierarchyTypeRDBLoad(RedisModuleIO *io, int encver) {
             goto error;
         }
 
+        /*
+         * Load the ids of child nodes.
+         */
         uint64_t nr_children = RedisModule_LoadUnsigned(io);
         Selva_NodeId *children __auto_free = NULL;
 
@@ -2296,7 +2299,8 @@ void *HierarchyTypeRDBLoad(RedisModuleIO *io, int encver) {
 
                 err = SelvaModify_AddHierarchy(NULL, hierarchy, child_id, 0, NULL, 0, NULL);
                 if (err < 0) {
-                    RedisModule_LogIOError(io, "warning", "Unable to rebuild the hierarchy");
+                    RedisModule_LogIOError(io, "warning", "Unable to rebuild the hierarchy: %s",
+                                           getSelvaErrorStr(err));
                     goto error;
                 }
 
@@ -2309,7 +2313,8 @@ void *HierarchyTypeRDBLoad(RedisModuleIO *io, int encver) {
          */
         err = SelvaModify_AddHierarchyP(NULL, hierarchy, node, 0, NULL, nr_children, children);
         if (err < 0) {
-            RedisModule_LogIOError(io, "warning", "Unable to rebuild the hierarchy");
+            RedisModule_LogIOError(io, "warning", "Unable to rebuild the hierarchy: %s",
+                                   getSelvaErrorStr(err));
             goto error;
         }
     }

--- a/server/modules/selva/test/units/test-svector.c
+++ b/server/modules/selva/test/units/test-svector.c
@@ -743,6 +743,35 @@ static char * test_foreach_large_fast_insert(void)
     return NULL;
 }
 
+static char * test_foreach_extra_large(void)
+{
+    struct data el[100000];
+    size_t i = 0;
+
+    SVector_Init(&vec, 300, compar);
+    for (i = 0; i < num_elem(el); i++) {
+        el[i].id = i;
+        SVector_Insert(&vec, &el[i]);
+        SVector_Insert(&vec, &el[i]);
+    }
+
+    pu_assert_equal("inserted all", i, 100000);
+    pu_assert_equal("size is correct", SVector_Size(&vec), 100000);
+
+    struct SVectorIterator it;
+    struct data *d;
+
+    i = 0;
+    SVector_ForeachBegin(&it, &vec);
+    while ((d = SVector_Foreach(&it))) {
+        i++;
+    }
+
+    pu_assert_equal("visited every item", i, 100000);
+
+    return NULL;
+}
+
 static char * test_get_index(void)
 {
     struct data el[] = { { 1 }, { 2 }, { 3 } };
@@ -801,6 +830,7 @@ void all_tests(void)
     pu_def_test(test_foreach_small, PU_RUN);
     pu_def_test(test_foreach_large, PU_RUN);
     pu_def_test(test_foreach_large_fast_insert, PU_RUN);
+    pu_def_test(test_foreach_extra_large, PU_RUN);
     pu_def_test(test_get_index, PU_RUN);
     pu_def_test(test_sizeof_ctrl, PU_RUN);
 }


### PR DESCRIPTION
`Svector` should only increment the size count if something was
inserted and refuse to insert the same data twice into an ordered
vector.

Currently if for example a children node_id list on modify
contains the same node_id more than once it makes `SVector_Size()`
and the actual vector size differ. This bug in turn breaks many
things already but it will also eventually completely break the
RDB serialization and deserialization and cause a crash.