### PR TITLE
Share common SelvaObject key strings

### DIFF
--- a/server/modules/selva/Makefile
+++ b/server/modules/selva/Makefile
@@ -32,6 +32,7 @@ OBJS := \
 	module/selva_object_commands.o \
 	module/selva_set.o \
 	module/selva_type.o \
+	module/shared.o \
 	module/subscriptions.o
 
 IDIR := $(patsubst %,-I%, $(INCLUDE_DIR))

--- a/server/modules/selva/doc/debugging.md
+++ b/server/modules/selva/doc/debugging.md
@@ -1,5 +1,22 @@
 # Debugging
 
+## Starting the Server Manually
+
+**On Linux**:
+
+```
+LD_LIBRARY_PATH=/usr/local/lib LOCPATH=/home/hbp/repos/selva/server/modules/binaries/linux_x64/locale ../binaries/linux_x64/redis-server-selva --loadmodule ./module.so FIND_INDEXING_INTERVAL 500 FIND_INDEXING_ICB_UPDATE_INTERVAL 100 FIND_INDICES_MAX 100
+```
+
+`LD_LIBRARY_PATH` is where your `hiredis` is supposed to be located.
+`LOCPATH` is for loading our custom locales.
+
+**On MacOS**:
+
+```
+../binaries/darwin_x64/redis-server-selva -- --loadmodule module.so
+```
+
 ## Dumping a Hierarchy Using redis-cli
 
 **hiearachy-dot-dump.js**
@@ -50,7 +67,7 @@ The `.gdbinit` file in the module directory will load some useful helpers from
 Start the server with GDB:
 
 ```
-gdb --args redis-server --loadmodule ./module.so
+LD_LIBRARY_PATH=/usr/local/lib LOCPATH=/home/hbp/repos/selva/server/modules/binaries/linux_x64/locale gdb --args ../binaries/linux_x64/redis-server-selva --loadmodule ./module.so 'FIND_INDEXING_INTERVAL' '500' 'FIND_INDEXING_ICB_UPDATE_INTERVAL' '1000' 'FIND_INDICES_MAX' 100
 ```
 
 **print-vector SYMBOL TYPE**
@@ -96,6 +113,12 @@ restart from `main()` after attaching to it.
 LLDB is partially compatible with GDB but many commands behave a bit differently
 and some commands don't exist with the same syntax.
 See the LLDB [Tutorial](https://lldb.llvm.org/use/tutorial.html).
+
+On MacOS the server can be also started manually with `lldb as follows:
+
+```
+lldb ../binaries/darwin_x64/redis-server-selva -- --loadmodule module.so
+```
 
 ## Valgrind
 
@@ -148,3 +171,7 @@ The path to the VTune binaries must be set in `$PATH`. Typically it's something
 like `/opt/intel/vtune_profiler_2021/bin64`. VTune can be installed on the
 remote by the local host over SSH, as long as the path you have selected is
 writable by the user.
+
+In the remote mode you can either provide a startup script for starting the test
+or run everything manually and attach to the running `redis-server-selva`
+process.

--- a/server/modules/selva/module/selva_set.c
+++ b/server/modules/selva/module/selva_set.c
@@ -224,6 +224,24 @@ void SelvaSet_Destroy(struct SelvaSet *set) {
     }
 }
 
+RedisModuleString *SelvaSet_FindRms(struct SelvaSet *set, RedisModuleString *s) {
+    struct SelvaSetElement find = {
+        .value_rms = s,
+    };
+    RedisModuleString *res = NULL;
+
+    if (likely(set->type == SELVA_SET_TYPE_RMSTRING)) {
+        struct SelvaSetElement *el;
+
+        el = RB_FIND(SelvaSetRms, &set->head_rms, &find);
+        if (el) {
+            res = el->value_rms;
+        }
+    }
+
+    return res;
+}
+
 int SelvaSet_HasRms(struct SelvaSet *set, RedisModuleString *s) {
     struct SelvaSetElement find = {
         .value_rms = s,

--- a/server/modules/selva/module/selva_set.h
+++ b/server/modules/selva/module/selva_set.h
@@ -107,7 +107,14 @@ int SelvaSet_AddNodeId(struct SelvaSet *set, const Selva_NodeId node_id);
         const char *: SelvaSet_AddNodeId \
         )((set), (x))
 
-int SelvaSet_HasRms(struct SelvaSet *set, RedisModuleString *s);
+/**
+ * Look for a string equal to s in the SelvaSet set.
+ * @returns Returns a pointer to a RedisModuleString stored in set if found;
+ *          Otherwise a NULL pointer is returned.
+ */
+struct RedisModuleString *SelvaSet_FindRms(struct SelvaSet *set, struct RedisModuleString *s);
+
+int SelvaSet_HasRms(struct SelvaSet *set, struct RedisModuleString *s);
 int SelvaSet_HasDouble(struct SelvaSet *set, double d);
 int SelvaSet_HasLongLong(struct SelvaSet *set, long long ll);
 int SelvaSet_HasNodeId(struct SelvaSet *set, const Selva_NodeId node_id);
@@ -119,7 +126,7 @@ int SelvaSet_HasNodeId(struct SelvaSet *set, const Selva_NodeId node_id);
         const char *: SelvaSet_HasNodeId \
         )((set), (x))
 
-struct SelvaSetElement *SelvaSet_RemoveRms(struct SelvaSet *set, RedisModuleString *s);
+struct SelvaSetElement *SelvaSet_RemoveRms(struct SelvaSet *set, struct RedisModuleString *s);
 struct SelvaSetElement *SelvaSet_RemoveDouble(struct SelvaSet *set, double d);
 struct SelvaSetElement *SelvaSet_RemoveLongLong(struct SelvaSet *set, long long ll);
 struct SelvaSetElement *SelvaSet_RemoveNodeId(struct SelvaSet *set, const Selva_NodeId node_id);

--- a/server/modules/selva/module/shared.c
+++ b/server/modules/selva/module/shared.c
@@ -1,0 +1,42 @@
+#include "selva_set.h"
+#include "redismodule.h"
+#include "cdefs.h"
+#include "shared.h"
+
+#define SELVA_SHARED_KEY_STR "type"
+#define SELVA_SHARED_KEY_LEN 4
+
+static struct SelvaSet shared_strings;
+
+RedisModuleString *Share_RMS(const char *key_str, size_t key_len, RedisModuleString *rms) {
+    RedisModuleString *out;
+
+    if (key_len != SELVA_SHARED_KEY_LEN ||
+        memcmp(key_str, SELVA_SHARED_KEY_STR, SELVA_SHARED_KEY_LEN)) {
+        return NULL;
+    }
+
+    out = SelvaSet_FindRms(&shared_strings, rms);
+    if (!out) {
+        int err;
+
+        out = RedisModule_HoldString(NULL, rms);
+        err = SelvaSet_Add(&shared_strings, out);
+        if (err) {
+            RedisModule_FreeString(NULL, rms);
+            return NULL;
+        }
+    }
+
+    /*
+     * Hodl it even if we just added it to the data structure so we can keep
+     * it in the set even if/when the caller tries to free the string.
+     */
+    RedisModule_RetainString(NULL, out);
+
+    return out;
+}
+
+__constructor static void init_shared(void) {
+    SelvaSet_Init(&shared_strings, SELVA_SET_TYPE_RMSTRING);
+}

--- a/server/modules/selva/module/shared.h
+++ b/server/modules/selva/module/shared.h
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef _SELVA_SHARED_H_
+#define _SELVA_SHARED_H_
+
+struct RedisModuleString;
+
+/**
+ * Share a RedisModuleString.
+ * Anything passed to this function is expected to be needed forever read-only
+ * and there is no way to free anything nor determine if something could be
+ * freed. This storage model is ideal for things like type strings that are
+ * unlikely to ever change or change extremely rarely but are still used
+ * everywhere.
+ *
+ * @returns If rms is not shared yet it will be added to the internal data structure;
+ *          If rms is shared a pointer to the previously shared RedisModuleString is returned;
+ *          A NULL pointer is returned if adding rms to the internal data structure fails.
+ */
+struct RedisModuleString *Share_RMS(const char *key_str, size_t key_len, struct RedisModuleString *rms);
+
+#endif /* _SELVA_SHARED_H_ */


### PR DESCRIPTION
`"type"` field can only a have a few distinct value so we could
easily share the memory location for those values.

However, we can only do th sharing in very specific places where
we have explicit control over the value string, e.g. modify and
RDB loading.

This will save about 1.5 MB of memory per 100k nodes in a db
having just a few distinct types.

Note that there is no way to free the shared strings once allocated
but that shouldn't be a huge issue because the type strings are
short and rarely change or go away.