### PR TITLE
Allow doing full DFS from find

### DIFF
--- a/server/modules/selva/module/traversal.c
+++ b/server/modules/selva/module/traversal.c
@@ -56,6 +56,8 @@ int SelvaTraversal_ParseDir2(enum SelvaTraversal *dir, const RedisModuleString *
         *dir = SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION;
     } else if (!strcmp("expression", arg_str)) {
         *dir = SELVA_HIERARCHY_TRAVERSAL_EXPRESSION;
+    } else if (!strcmp("dfs_full", arg_str)) {
+        *dir = SELVA_HIERARCHY_TRAVERSAL_DFS_FULL;
     } else {
         return SELVA_SUBSCRIPTIONS_EINVAL;
     }
@@ -416,7 +418,6 @@ int SelvaTraversal_GetSkip(enum SelvaTraversal dir) {
     case SELVA_HIERARCHY_TRAVERSAL_BFS_DESCENDANTS:
     case SELVA_HIERARCHY_TRAVERSAL_DFS_ANCESTORS:
     case SELVA_HIERARCHY_TRAVERSAL_DFS_DESCENDANTS:
-    case SELVA_HIERARCHY_TRAVERSAL_DFS_FULL:
     case SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION:
         return 1;
     default:


### PR DESCRIPTION
Example:

```
SELVA.HIERARCHY.find "" ___selva_hierarchy dfs_full aaaaaaaaaa
```

`aaaaaaaaaa` is a dummy nodeId because at least one nodeId is
always required by the command logic. In the case of dfs_full the
nodeId will be just ignored and all heads will be traversed.

All the usual query modifiers work normally with the search, e.g.
`limit`, `fields` or adding an RPN filter are fully supported.