### PR TITLE
Fix deflate build on macOS

### DIFF
--- a/server/modules/selva/lib/deflate/Makefile
+++ b/server/modules/selva/lib/deflate/Makefile
@@ -221,7 +221,9 @@ $(SHARED_LIB):$(SHARED_LIB_OBJ)
 		$(SHARED_LIB_LDFLAGS) -shared $+
 
 ifdef DISABLE_SHARED
-undefine SHARED_LIB_SYMLINK
+	ifneq ($(shell uname),Darwin)
+		undefine SHARED_LIB_SYMLINK
+	endif
 else
 DEFAULT_TARGETS += $(SHARED_LIB)
 endif


### PR DESCRIPTION
GNU make on macOS is at version 3.81 but `undefine` is only
supported since 3.82.