### PR TITLE
Wrapping external traversals is unccessary

### DIFF
--- a/server/modules/selva/module/hierarchy.c
+++ b/server/modules/selva/module/hierarchy.c
@@ -77,30 +77,6 @@ enum SelvaHierarchyNode_Relationship {
     RELATIONSHIP_CHILD,
 };
 
-typedef void (*HierarchyNode_HeadCallback)(SelvaHierarchyNode *node, void *arg);
-
-typedef void (*HierarchyNode_ChildCallback)(SelvaHierarchyNode *parent, SelvaHierarchyNode *child, void *arg);
-
-typedef struct TraversalCallback {
-    /**
-     * Called for each orphan head in the hierarchy.
-     */
-    HierarchyNode_HeadCallback head_cb;
-    void * head_arg;
-
-    /**
-     * Called for each node in the hierarchy.
-     */
-    SelvaHierarchyNodeCallback node_cb;
-    void * node_arg;
-
-    /**
-     * Called for each child of current node.
-     */
-    HierarchyNode_ChildCallback child_cb;
-    void * child_arg;
-} TraversalCallback;
-
 /**
  * Structure for traversal cb of verifyDetachableSubtree().
  */
@@ -1566,7 +1542,7 @@ int SelvaModify_DelHierarchyNode(
     return SelvaModify_DelHierarchyNodeP(ctx, hierarchy, node, flags, NULL);
 }
 
-static void HierarchyNode_HeadCallback_Dummy(SelvaHierarchyNode *node, void *arg) {
+static void SelvaHierarchyHeadCallback_Dummy(SelvaHierarchyNode *node, void *arg) {
     REDISMODULE_NOT_USED(node);
     REDISMODULE_NOT_USED(arg);
 }
@@ -1578,7 +1554,7 @@ static int HierarchyNode_Callback_Dummy(SelvaHierarchyNode *node, void *arg) {
     return 0;
 }
 
-static void HierarchyNode_ChildCallback_Dummy(SelvaHierarchyNode *parent, SelvaHierarchyNode *child, void *arg) {
+static void SelvaHierarchyChildCallback_Dummy(SelvaHierarchyNode *parent, SelvaHierarchyNode *child, void *arg) {
     REDISMODULE_NOT_USED(parent);
     REDISMODULE_NOT_USED(child);
     REDISMODULE_NOT_USED(arg);
@@ -1591,11 +1567,11 @@ static int dfs(
         SelvaHierarchy *hierarchy,
         SelvaHierarchyNode *head,
         enum SelvaHierarchyNode_Relationship dir,
-        const TraversalCallback * restrict cb) {
-    size_t offset;
-    HierarchyNode_HeadCallback head_cb = cb->head_cb ? cb->head_cb : &HierarchyNode_HeadCallback_Dummy;
+        const struct SelvaHierarchyCallback * restrict cb) {
+    SelvaHierarchyHeadCallback head_cb = cb->head_cb ? cb->head_cb : &SelvaHierarchyHeadCallback_Dummy;
     SelvaHierarchyNodeCallback node_cb = cb->node_cb ? cb->node_cb : &HierarchyNode_Callback_Dummy;
-    HierarchyNode_ChildCallback child_cb = cb->child_cb ? cb->child_cb : &HierarchyNode_ChildCallback_Dummy;
+    SelvaHierarchyChildCallback child_cb = cb->child_cb ? cb->child_cb : &SelvaHierarchyChildCallback_Dummy;
+    size_t offset;
 
     switch (dir) {
     case RELATIONSHIP_PARENT:
@@ -1666,13 +1642,12 @@ out:
 /**
  * Traverse through all nodes of the hierarchy from heads to leaves.
  */
-static int full_dfs(SelvaHierarchy *hierarchy, const TraversalCallback * restrict cb) {
+static int full_dfs(SelvaHierarchy *hierarchy, const struct SelvaHierarchyCallback * restrict cb) {
+    SelvaHierarchyHeadCallback head_cb = cb->head_cb ? cb->head_cb : &SelvaHierarchyHeadCallback_Dummy;
+    SelvaHierarchyNodeCallback node_cb = cb->node_cb ? cb->node_cb : &HierarchyNode_Callback_Dummy;
+    SelvaHierarchyChildCallback child_cb = cb->child_cb ? cb->child_cb : &SelvaHierarchyChildCallback_Dummy;
     SelvaHierarchyNode *head;
     SVECTOR_AUTOFREE(stack);
-
-    HierarchyNode_HeadCallback head_cb = cb->head_cb ? cb->head_cb : &HierarchyNode_HeadCallback_Dummy;
-    SelvaHierarchyNodeCallback node_cb = cb->node_cb ? cb->node_cb : &HierarchyNode_Callback_Dummy;
-    HierarchyNode_ChildCallback child_cb = cb->child_cb ? cb->child_cb : &HierarchyNode_ChildCallback_Dummy;
 
     if (unlikely(!SVector_Init(&stack, selva_glob_config.hierarchy_expected_resp_len, NULL))) {
         return SELVA_HIERARCHY_ENOMEM;
@@ -1739,9 +1714,9 @@ out:
 }
 
 #define BFS_TRAVERSE(hierarchy, head, cb) \
-    HierarchyNode_HeadCallback head_cb = (cb)->head_cb ? (cb)->head_cb : HierarchyNode_HeadCallback_Dummy; \
+    SelvaHierarchyHeadCallback head_cb = (cb)->head_cb ? (cb)->head_cb : SelvaHierarchyHeadCallback_Dummy; \
     SelvaHierarchyNodeCallback node_cb = (cb)->node_cb ? (cb)->node_cb : HierarchyNode_Callback_Dummy; \
-    HierarchyNode_ChildCallback child_cb = (cb)->child_cb ? (cb)->child_cb : HierarchyNode_ChildCallback_Dummy; \
+    SelvaHierarchyChildCallback child_cb = (cb)->child_cb ? (cb)->child_cb : SelvaHierarchyChildCallback_Dummy; \
     \
     SVECTOR_AUTOFREE(_bfs_q); \
     if (unlikely(!SVector_Init(&_bfs_q, selva_glob_config.hierarchy_expected_resp_len, NULL))) { \
@@ -1800,7 +1775,7 @@ static __hot int bfs(
         SelvaHierarchy *hierarchy,
         SelvaHierarchyNode *head,
         enum SelvaHierarchyNode_Relationship dir,
-        const TraversalCallback * restrict cb) {
+        const struct SelvaHierarchyCallback * restrict cb) {
     size_t offset;
 
     switch (dir) {
@@ -1829,7 +1804,7 @@ static int bfs_edge(
         SelvaHierarchyNode *head,
         const char *field_name_str,
         size_t field_name_len,
-        const TraversalCallback * restrict cb) {
+        const struct SelvaHierarchyCallback * restrict cb) {
     BFS_TRAVERSE(hierarchy, head, cb) {
         const struct EdgeField *edge_field;
 
@@ -1878,7 +1853,7 @@ static int bfs_expression(
         SelvaHierarchyNode *head,
         struct rpn_ctx *rpn_ctx,
         const struct rpn_expression *rpn_expr,
-        const TraversalCallback * restrict cb) {
+        const struct SelvaHierarchyCallback * restrict cb) {
     BFS_TRAVERSE(hierarchy, head, cb) {
         enum rpn_error rpn_err;
         struct SelvaSet fields;
@@ -1920,7 +1895,7 @@ static int bfs_expression(
 static int traverse_adjacent(
         SelvaHierarchyNode *head,
         enum SelvaTraversal dir,
-        const TraversalCallback *tcb) {
+        const struct SelvaHierarchyCallback *tcb) {
     const SVector *adjVec;
     struct SVectorIterator it;
     SelvaHierarchyNode *node;
@@ -2012,14 +1987,6 @@ static int traverse_bfs_edge_field(
         const char *field_name_str,
         size_t field_name_len,
         const struct SelvaHierarchyCallback *cb) {
-    const TraversalCallback tcb = {
-        .head_cb = NULL,
-        .head_arg = NULL,
-        .node_cb = cb->node_cb,
-        .node_arg = cb->node_arg,
-        .child_cb = NULL,
-        .child_arg = NULL,
-    };
     SelvaHierarchyNode *head;
 
     head = SelvaHierarchy_FindNode(hierarchy, id);
@@ -2027,7 +1994,7 @@ static int traverse_bfs_edge_field(
         return SELVA_HIERARCHY_ENOENT;
     }
 
-    return bfs_edge(hierarchy, head, field_name_str, field_name_len, &tcb);
+    return bfs_edge(hierarchy, head, field_name_str, field_name_len, cb);
 }
 
 static int traverse_array(
@@ -2064,14 +2031,6 @@ int SelvaModify_TraverseHierarchy(
         const Selva_NodeId id,
         enum SelvaTraversal dir,
         const struct SelvaHierarchyCallback *cb) {
-    const TraversalCallback tcb = {
-        .head_cb = NULL,
-        .head_arg = NULL,
-        .node_cb = cb->node_cb,
-        .node_arg = cb->node_arg,
-        .child_cb = NULL,
-        .child_arg = NULL,
-    };
     SelvaHierarchyNode *head;
     int err;
 
@@ -2093,22 +2052,22 @@ int SelvaModify_TraverseHierarchy(
         break;
     case SELVA_HIERARCHY_TRAVERSAL_CHILDREN:
     case SELVA_HIERARCHY_TRAVERSAL_PARENTS:
-        err = traverse_adjacent(head, dir, &tcb);
+        err = traverse_adjacent(head, dir, cb);
         break;
     case SELVA_HIERARCHY_TRAVERSAL_BFS_ANCESTORS:
-        err = bfs(hierarchy, head, RELATIONSHIP_PARENT, &tcb);
+        err = bfs(hierarchy, head, RELATIONSHIP_PARENT, cb);
         break;
     case SELVA_HIERARCHY_TRAVERSAL_BFS_DESCENDANTS:
-        err = bfs(hierarchy, head, RELATIONSHIP_CHILD, &tcb);
+        err = bfs(hierarchy, head, RELATIONSHIP_CHILD, cb);
         break;
     case SELVA_HIERARCHY_TRAVERSAL_DFS_ANCESTORS:
-        err = dfs(hierarchy, head, RELATIONSHIP_PARENT, &tcb);
+        err = dfs(hierarchy, head, RELATIONSHIP_PARENT, cb);
         break;
      case SELVA_HIERARCHY_TRAVERSAL_DFS_DESCENDANTS:
-        err = dfs(hierarchy, head, RELATIONSHIP_CHILD, &tcb);
+        err = dfs(hierarchy, head, RELATIONSHIP_CHILD, cb);
         break;
      case SELVA_HIERARCHY_TRAVERSAL_DFS_FULL:
-        err = full_dfs(hierarchy, &tcb);
+        err = full_dfs(hierarchy, cb);
         break;
      default:
         /* Should probably use some other traversal function. */
@@ -2222,14 +2181,6 @@ int SelvaHierarchy_TraverseExpressionBfs(
         struct rpn_ctx *rpn_ctx,
         const struct rpn_expression *rpn_expr,
         const struct SelvaHierarchyCallback *cb) {
-    const TraversalCallback tcb = {
-        .head_cb = NULL,
-        .head_arg = NULL,
-        .node_cb = cb->node_cb,
-        .node_arg = cb->node_arg,
-        .child_cb = NULL,
-        .child_arg = NULL,
-    };
     SelvaHierarchyNode *head;
 
     head = SelvaHierarchy_FindNode(hierarchy, id);
@@ -2237,7 +2188,7 @@ int SelvaHierarchy_TraverseExpressionBfs(
         return SELVA_HIERARCHY_ENOENT;
     }
 
-    return bfs_expression(ctx, hierarchy, head, rpn_ctx, rpn_expr, &tcb);
+    return bfs_expression(ctx, hierarchy, head, rpn_ctx, rpn_expr, cb);
 }
 
 int SelvaModify_TraverseArray(
@@ -2476,7 +2427,7 @@ static void HierarchyRDBSaveChild(SelvaHierarchyNode *parent, SelvaHierarchyNode
 
 static void Hierarchy_RDBSave(RedisModuleIO *io, void *value) {
     SelvaHierarchy *hierarchy = (SelvaHierarchy *)value;
-    const TraversalCallback cb = {
+    const struct SelvaHierarchyCallback cb = {
         .head_cb = NULL,
         .head_arg = NULL,
         .node_cb = HierarchyRDBSaveNode,
@@ -2564,7 +2515,7 @@ static void Hierarchy_SubtreeRDBSave(RedisModuleIO *io, void *value) {
     struct SelvaHierarchySubtree *subtree = (struct SelvaHierarchySubtree *)value;
     SelvaHierarchy *hierarchy = subtree->hierarchy;
     struct SelvaHierarchyNode *node = subtree->node;
-    const TraversalCallback cb = {
+    const struct SelvaHierarchyCallback cb = {
         .head_cb = NULL,
         .head_arg = NULL,
         .node_cb = HierarchyRDBSaveNode,
@@ -2647,7 +2598,7 @@ static int verifyDetachableSubtree(SelvaHierarchy *hierarchy, struct SelvaHierar
         .err = 0,
         .head = node,
     };
-    const TraversalCallback cb = {
+    const struct SelvaHierarchyCallback cb = {
         .head_cb = NULL,
         .head_arg = NULL,
         .node_cb = verifyDetachableSubtreeNodeCb,

--- a/server/modules/selva/module/hierarchy.h
+++ b/server/modules/selva/module/hierarchy.h
@@ -146,14 +146,27 @@ struct SelvaHierarchy {
     } index_detached;
 };
 
+/**
+ * Called for the first node in the traversal.
+ * This is typically the node that was given as an argument to a traversal function.
+ * @param node a pointer to the node.
+ * @param arg a pointer to head_arg give in SelvaHierarchyCallback structure.
+ */
 typedef void (*SelvaHierarchyHeadCallback)(struct SelvaHierarchyNode *node, void *arg);
 
 /**
  * Called for each node found during a traversal.
+ * @param node a pointer to the node.
+ * @param arg a pointer to node_arg give in SelvaHierarchyCallback structure.
  * @returns 0 to continue the traversal; 1 to interrupt the traversal.
  */
 typedef int (*SelvaHierarchyNodeCallback)(struct SelvaHierarchyNode *node, void *arg);
 
+/**
+ * Called for each adjacent node during a traversal.
+ * @param node a pointer to the node.
+ * @param arg a pointer to child_arg give in SelvaHierarchyCallback structure.
+ */
 typedef void (*SelvaHierarchyChildCallback)(struct SelvaHierarchyNode *parent, struct SelvaHierarchyNode *child, void *arg);
 
 struct SelvaHierarchyCallback {

--- a/server/modules/selva/module/hierarchy.h
+++ b/server/modules/selva/module/hierarchy.h
@@ -150,10 +150,10 @@ struct SelvaHierarchy {
  * Called for each node found during a traversal.
  * @returns 0 to continue the traversal; 1 to interrupt the traversal.
  */
-typedef int (*SelvaHierarchyCallback)(struct SelvaHierarchyNode *node, void *arg);
+typedef int (*SelvaHierarchyNodeCallback)(struct SelvaHierarchyNode *node, void *arg);
 
 struct SelvaHierarchyCallback {
-    SelvaHierarchyCallback node_cb;
+    SelvaHierarchyNodeCallback node_cb;
     void * node_arg;
 };
 

--- a/server/modules/selva/module/hierarchy.h
+++ b/server/modules/selva/module/hierarchy.h
@@ -146,15 +146,34 @@ struct SelvaHierarchy {
     } index_detached;
 };
 
+typedef void (*SelvaHierarchyHeadCallback)(struct SelvaHierarchyNode *node, void *arg);
+
 /**
  * Called for each node found during a traversal.
  * @returns 0 to continue the traversal; 1 to interrupt the traversal.
  */
 typedef int (*SelvaHierarchyNodeCallback)(struct SelvaHierarchyNode *node, void *arg);
 
+typedef void (*SelvaHierarchyChildCallback)(struct SelvaHierarchyNode *parent, struct SelvaHierarchyNode *child, void *arg);
+
 struct SelvaHierarchyCallback {
+    /**
+     * Called for each orphan head in the hierarchy.
+     */
+    SelvaHierarchyHeadCallback head_cb;
+    void * head_arg;
+
+    /**
+     * Called for each node in the hierarchy.
+     */
     SelvaHierarchyNodeCallback node_cb;
     void * node_arg;
+
+    /**
+     * Called for each child of current node.
+     */
+    SelvaHierarchyChildCallback child_cb;
+    void * child_arg;
 };
 
 typedef int (*SelvaModify_ArrayObjectCallback)(struct SelvaObject *obj, void *arg);


### PR DESCRIPTION
Wrapping external hierarchy traversals hasn't been necessary since
the node pointer interface was implemented.