### PR TITLE
Fix dynamic edge constraints used after reload

### DIFF
--- a/client/test/edgeField.ts
+++ b/client/test/edgeField.ts
@@ -3,7 +3,7 @@ const { compile, createRecord } = require('data-record')
 import { connect } from '../src/index'
 import { setRecordDefCstring } from '../src/set/modifyDataRecords'
 import { start } from '@saulx/selva-server'
-import redis, { RedisClient } from '@/saulx/redis-client'
+import redis, { RedisClient } from '@saulx/redis-client'
 import './assertions'
 import { wait } from './assertions'
 import getPort from 'get-port'

--- a/client/test/rdb.ts
+++ b/client/test/rdb.ts
@@ -240,4 +240,59 @@ test.serial('can reload from RDB', async (t) => {
     type: 'lekkerType',
     title: { en: 'sup' },
   })
+
+  // Do it again
+  await client.redis.save()
+  await wait(1000)
+  await restartServer()
+  await client.destroy()
+  await wait(5000)
+  client = connect({ port })
+
+  t.deepEqual(await client.get({ $id: 'viTest', $all: true, parents: true }), {
+    id: 'viTest',
+    type: 'lekkerType',
+    parents: ['root'],
+    title: { en: 'hello' },
+    stringAry: ['hello', 'world'],
+    doubleAry: [1.0, 2.1, 3.2],
+    intAry: [7, 6, 5, 4, 3, 2, 999],
+    objAry: [
+      {
+        textyText: {
+          en: 'hello 1',
+          de: 'hallo 1',
+        },
+        strField: 'string value hello 1',
+        numField: 112,
+      },
+      {
+        textyText: {
+          en: 'hello 2',
+          de: 'hallo 2',
+        },
+        strField: 'string value hello 2',
+        numField: 113,
+      },
+    ],
+  })
+
+  t.deepEqual(await client.get({ $id: 'viLink1', $all: true, lekkerLink: true, fren: true }), {
+    id: 'viLink1',
+    type: 'lekkerType',
+    title: { en: 'hi' },
+    lekkerLink: 'viLink2',
+    fren: 'viLink3',
+  })
+  t.deepEqual(await client.get({ $id: 'viLink2', $all: true, lekkerLink: true, fren: true }), {
+    id: 'viLink2',
+    type: 'lekkerType',
+    title: { en: 'yo' },
+    lekkerLink: 'viLink1',
+  })
+  t.deepEqual(await client.get({ $id: 'viLink3', $all: true, lekkerLink: true, fren: true }), {
+    id: 'viLink3',
+    type: 'lekkerType',
+    title: { en: 'sup' },
+  })
 })

--- a/server/modules/selva/module/edge.c
+++ b/server/modules/selva/module/edge.c
@@ -802,7 +802,7 @@ static void EdgeField_RdbSave(struct RedisModuleIO *io, void *value, __unused vo
     if (constraint_id == EDGE_FIELD_CONSTRAINT_DYNAMIC) {
         const struct EdgeFieldConstraint *constraint = edgeField->constraint;
 
-        RedisModule_SaveStringBuffer(io, constraint->node_type, SELVA_NODE_TYPE_SIZE);
+        RedisModule_SaveStringBuffer(io, edgeField->src_node_id, SELVA_NODE_TYPE_SIZE);
         RedisModule_SaveStringBuffer(io, constraint->field_name_str, constraint->field_name_len);
     }
     RedisModule_SaveUnsigned(io, SVector_Size(&edgeField->arcs)); /* nr_edges */

--- a/server/modules/selva/module/edge.h
+++ b/server/modules/selva/module/edge.h
@@ -52,8 +52,6 @@ struct EdgeFieldConstraint {
      */
     unsigned char flags;
 
-    Selva_NodeType node_type;
-
     /**
      * Forward traversing field of this constraint.
      */

--- a/server/modules/selva/module/edge_constraint.c
+++ b/server/modules/selva/module/edge_constraint.c
@@ -74,7 +74,6 @@ static struct EdgeFieldConstraint *create_constraint(const struct EdgeFieldDynCo
 
     p->constraint_id = EDGE_FIELD_CONSTRAINT_DYNAMIC;
     p->flags = params->flags | EDGE_FIELD_CONSTRAINT_FLAG_DYNAMIC;
-    memcpy(p->node_type, params->fwd_node_type, SELVA_NODE_TYPE_SIZE);
     p->field_name_str = (char *)p + sizeof(*p);
     p->field_name_len = fwd_field_name_len;
     memcpy(p->field_name_str, fwd_field_name_str, fwd_field_name_len);
@@ -170,8 +169,6 @@ static void *so_rdb_load(struct RedisModuleIO *io, int encver __unused, void *lo
     struct EdgeFieldDynConstraintParams params = { 0 };
 
     params.flags = RedisModule_LoadUnsigned(io);
-
-    /* create_constraint() doesn't need params.fwd_node_type */
 
     params.fwd_field_name = RedisModule_LoadString(io);
     if (params.flags & EDGE_FIELD_CONSTRAINT_FLAG_BIDIRECTIONAL) {


### PR DESCRIPTION
1. create a dynamic edge constraint
2. save, shutdown, and restart Redis
3. Use the previously created dynamic constraint in a new edge field
4. save, shutdown, and restart
5. The edge field fails to load because the constraint cannot be found