### PR TITLE
Simplify and unify the traversals

### DIFF
--- a/server/modules/selva/module/aggregate.c
+++ b/server/modules/selva/module/aggregate.c
@@ -757,13 +757,13 @@ int SelvaHierarchy_AggregateCommand(RedisModuleCtx *ctx, RedisModuleString **arg
                            SELVA_HIERARCHY_TRAVERSAL_BFS_EDGE_FIELD))) {
             TO_STR(ref_field);
 
-            err = SelvaModify_TraverseHierarchyField(hierarchy, nodeId, dir, ref_field_str, ref_field_len, &cb);
+            err = SelvaHierarchy_TraverseField(hierarchy, nodeId, dir, ref_field_str, ref_field_len, &cb);
         } else if (dir == SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION) {
             err = SelvaHierarchy_TraverseExpressionBfs(ctx, hierarchy, nodeId, traversal_rpn_ctx, traversal_expression, &cb);
         } else if (dir == SELVA_HIERARCHY_TRAVERSAL_EXPRESSION) {
             err = SelvaHierarchy_TraverseExpression(ctx, hierarchy, nodeId, traversal_rpn_ctx, traversal_expression, &cb);
         } else {
-            err = SelvaModify_TraverseHierarchy(hierarchy, nodeId, dir, &cb);
+            err = SelvaHierarchy_Traverse(hierarchy, nodeId, dir, &cb);
         }
         if (err != 0) {
             /*

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -1696,7 +1696,7 @@ static int SelvaHierarchy_FindCommand(RedisModuleCtx *ctx, RedisModuleString **a
             TO_STR(ref_field);
 
             SELVA_TRACE_BEGIN(cmd_find_refs);
-            err = SelvaModify_TraverseHierarchyField(hierarchy, nodeId, dir, ref_field_str, ref_field_len, &cb);
+            err = SelvaHierarchy_TraverseField(hierarchy, nodeId, dir, ref_field_str, ref_field_len, &cb);
             SELVA_TRACE_END(cmd_find_refs);
         } else if (dir == SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION) {
             SELVA_TRACE_BEGIN(cmd_find_bfs_expression);
@@ -1708,7 +1708,7 @@ static int SelvaHierarchy_FindCommand(RedisModuleCtx *ctx, RedisModuleString **a
             SELVA_TRACE_END(cmd_find_traversal_expression);
         } else {
             SELVA_TRACE_BEGIN(cmd_find_rest);
-            err = SelvaModify_TraverseHierarchy(hierarchy, nodeId, dir, &cb);
+            err = SelvaHierarchy_Traverse(hierarchy, nodeId, dir, &cb);
             SELVA_TRACE_END(cmd_find_rest);
         }
         for (int j = 0; j < nr_index_hints; j++) {

--- a/server/modules/selva/module/hierarchy.c
+++ b/server/modules/selva/module/hierarchy.c
@@ -1604,7 +1604,8 @@ static int dfs(
 
     SVector_Insert(&stack, head);
     if (head_cb(head, cb->head_arg)) {
-        return 0;
+        err = 0;
+        goto out;
     }
 
     while (SVector_Size(&stack) > 0) {
@@ -1691,7 +1692,8 @@ static int full_dfs(SelvaHierarchy *hierarchy, const struct SelvaHierarchyCallba
         }
 
         if (head_cb(head, cb->head_arg)) {
-            return 0;
+            err = 0;
+            goto out;
         }
 
         while (SVector_Size(&stack) > 0) {
@@ -1747,7 +1749,7 @@ out:
     \
     Trx_Visit(&trx_cur, &(head)->trx_label); \
     SVector_Insert(&_bfs_q, (head)); \
-    if (head_cb((head), (cb)->head_arg)) { return 0; } \
+    if (head_cb((head), (cb)->head_arg)) { Trx_End(&hierarchy->trx_state, &trx_cur); return 0; } \
     while (SVector_Size(&_bfs_q) > 0) { \
         SelvaHierarchyNode *node = SVector_Shift(&_bfs_q);
 

--- a/server/modules/selva/module/hierarchy.h
+++ b/server/modules/selva/module/hierarchy.h
@@ -152,7 +152,7 @@ struct SelvaHierarchy {
  * @param node a pointer to the node.
  * @param arg a pointer to head_arg give in SelvaHierarchyCallback structure.
  */
-typedef void (*SelvaHierarchyHeadCallback)(struct SelvaHierarchyNode *node, void *arg);
+typedef int (*SelvaHierarchyHeadCallback)(struct SelvaHierarchyNode *node, void *arg);
 
 /**
  * Called for each node found during a traversal.
@@ -403,12 +403,12 @@ static inline int SelvaHierarchy_NodeExists(SelvaHierarchy *hierarchy, const Sel
  */
 ssize_t SelvaModify_GetHierarchyHeads(SelvaHierarchy *hierarchy, Selva_NodeId **res);
 
-int SelvaModify_TraverseHierarchy(
+int SelvaHierarchy_Traverse(
         SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
         enum SelvaTraversal dir,
         const struct SelvaHierarchyCallback *cb);
-int SelvaModify_TraverseHierarchyField(
+int SelvaHierarchy_TraverseField(
         SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
         enum SelvaTraversal dir,

--- a/server/modules/selva/module/hierarchy_reply.c
+++ b/server/modules/selva/module/hierarchy_reply.c
@@ -73,7 +73,7 @@ int HierarchyReply_WithTraversal(
      * [nodeId1, nodeId2,.. nodeIdn]
      */
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-    err = SelvaModify_TraverseHierarchy(hierarchy, nodeId, dir, &cb);
+    err = SelvaHierarchy_Traverse(hierarchy, nodeId, dir, &cb);
     RedisModule_ReplySetArrayLength(ctx, args.len);
 
     return err;

--- a/server/modules/selva/module/inherit.c
+++ b/server/modules/selva/module/inherit.c
@@ -399,7 +399,7 @@ int SelvaInheritCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         .node_arg = &args,
     };
 
-    err = SelvaModify_TraverseHierarchy(hierarchy, node_id, SELVA_HIERARCHY_TRAVERSAL_BFS_ANCESTORS, &cb);
+    err = SelvaHierarchy_Traverse(hierarchy, node_id, SELVA_HIERARCHY_TRAVERSAL_BFS_ANCESTORS, &cb);
     RedisModule_ReplySetArrayLength(ctx, args.nr_results);
 
     if (err) {

--- a/server/modules/selva/module/subscriptions.h
+++ b/server/modules/selva/module/subscriptions.h
@@ -236,18 +236,6 @@ int Selva_Subscriptions_InitHierarchy(struct SelvaHierarchy *hierarchy);
 void SelvaSubscriptions_DestroyAll(struct RedisModuleCtx *ctx, struct SelvaHierarchy *hierarchy);
 
 /**
- * Do a traversal over the given marker.
- * Bear in mind that cb is passed directly to the hierarchy traversal, thus any
- * filter set in the marker is not executed and the callback must execute the
- * filter if required.
- */
-int SelvaSubscriptions_TraverseMarker(
-        struct RedisModuleCtx *ctx,
-        struct SelvaHierarchy *hierarchy,
-        struct Selva_SubscriptionMarker *marker,
-        const struct SelvaHierarchyCallback *cb);
-
-/**
  * Refresh a marker by id.
  * Note that in contrary to other refresh functions this one will only traverse
  * and refresh a single marker of the given subscription.

--- a/server/modules/selva/module/traversal.h
+++ b/server/modules/selva/module/traversal.h
@@ -12,7 +12,7 @@ enum SelvaTraversalAlgo {
 
 /**
  * Hierarchy traversal order.
- * Recognized by SelvaModify_TraverseHierarchy().
+ * Recognized by SelvaHierarchy_Traverse().
  */
 enum SelvaTraversal {
     SELVA_HIERARCHY_TRAVERSAL_NONE =            0x0000, /*!< Do nothing. */

--- a/server/modules/selva/test/units/test-hierarchy.c
+++ b/server/modules/selva/test/units/test-hierarchy.c
@@ -65,7 +65,7 @@ static ssize_t SelvaModify_FindAncestors(SelvaHierarchy *hierarchy, const Selva_
     };
     int err;
 
-    err = SelvaModify_TraverseHierarchy(hierarchy, id, SELVA_HIERARCHY_TRAVERSAL_DFS_ANCESTORS, &cb);
+    err = SelvaHierarchy_Traverse(hierarchy, id, SELVA_HIERARCHY_TRAVERSAL_DFS_ANCESTORS, &cb);
     *ancestors = list;
     if (err) {
         return err;
@@ -84,7 +84,7 @@ ssize_t SelvaModify_FindDescendants(SelvaHierarchy *hierarchy, const Selva_NodeI
     };
     int err;
 
-    err = SelvaModify_TraverseHierarchy(hierarchy, id, SELVA_HIERARCHY_TRAVERSAL_DFS_DESCENDANTS, &cb);
+    err = SelvaHierarchy_Traverse(hierarchy, id, SELVA_HIERARCHY_TRAVERSAL_DFS_DESCENDANTS, &cb);
     *descendants = list;
     if (err) {
         return err;


### PR DESCRIPTION
- Traversals should always support the head callback
- head callback should be allowed to stop the traversal
- Use the head callback where necessary instead of doing
  two traversals