### PR TITLE
Fix nested queries ref with $all

### DIFF
--- a/client/src/get/createGetOperations/all.ts
+++ b/client/src/get/createGetOperations/all.ts
@@ -68,7 +68,9 @@ const all = (
           key !== 'children' &&
           key !== 'parents' &&
           key !== 'ancestors' &&
-          key !== 'descendants'
+          key !== 'descendants' &&
+          typeSchema.fields[key].type !== 'reference' &&
+          typeSchema.fields[key].type !== 'references'
         ) {
           ops.push({
             type: 'db',
@@ -98,6 +100,11 @@ const all = (
     if (fieldSchema.type === 'object') {
       for (const key in fieldSchema.properties) {
         if (props[key] === undefined) {
+          const keySchema = fieldSchema.properties[key]
+          if (['reference', 'references'].includes(keySchema.type)) {
+            return
+          }
+
           ops.push({
             type: 'db',
             id,
@@ -132,7 +139,7 @@ const all = (
         field: field.slice(1),
         sourceField: field.slice(1),
         fromReference: true,
-        props: { $all: true },
+        props: Object.assign({}, props, { $all: true }),
       })
     }
   }

--- a/client/test/getBasic.ts
+++ b/client/test/getBasic.ts
@@ -931,18 +931,18 @@ test.serial('get - references', async (t) => {
     refs: [id1, id11],
   })
 
-  // this should no longer work (we don't return ref/refs types with $all by default
-  // t.deepEqualIgnoreOrder(
-  //   await client.get({
-  //     $id: id2,
-  //     $all: true,
-  //   }),
-  //   {
-  //     id: id2,
-  //     type: 'lekkerType',
-  //     refs: [id1, id11],
-  //   }
-  // )
+  t.deepEqualIgnoreOrder(
+    await client.get({
+      $id: id2,
+      $all: true,
+    }),
+    {
+      id: id2,
+      type: 'lekkerType',
+      // this should no longer work (we don't return ref/refs types with $all by default
+      // refs: [id1, id11],
+    }
+  )
 
   client.destroy()
 })

--- a/client/test/getBasic.ts
+++ b/client/test/getBasic.ts
@@ -931,17 +931,18 @@ test.serial('get - references', async (t) => {
     refs: [id1, id11],
   })
 
-  t.deepEqualIgnoreOrder(
-    await client.get({
-      $id: id2,
-      $all: true,
-    }),
-    {
-      id: id2,
-      type: 'lekkerType',
-      refs: [id1, id11],
-    }
-  )
+  // this should no longer work (we don't return ref/refs types with $all by default
+  // t.deepEqualIgnoreOrder(
+  //   await client.get({
+  //     $id: id2,
+  //     $all: true,
+  //   }),
+  //   {
+  //     id: id2,
+  //     type: 'lekkerType',
+  //     refs: [id1, id11],
+  //   }
+  // )
 
   client.destroy()
 })

--- a/client/test/reference.ts
+++ b/client/test/reference.ts
@@ -610,6 +610,39 @@ test.serial('list of simple singular reference', async (t) => {
     }
   )
 
+  await client.set({
+    $id: 'maA',
+    bidirClub: 'clA',
+  })
+
+  t.deepEqual(
+    await client.get({
+      $id: 'clA',
+      $all: true,
+      specialMatch: {
+        $all: true,
+        bidirClub: {
+          $all: true,
+        },
+      },
+    }),
+    {
+      id: 'clA',
+      type: 'club',
+      title: { en: 'yesh club' },
+      specialMatch: {
+        id: 'maA',
+        title: { en: 'yesh match' },
+        type: 'match',
+        bidirClub: {
+          id: 'clA',
+          type: 'club',
+          title: { en: 'yesh club' },
+        },
+      },
+    }
+  )
+
   t.deepEqual(
     await client.get({
       $id: 'root',


### PR DESCRIPTION
Fixes two things:

1) passes advanced options when querying nested references (before this always implied simply `myRef: { $all: true }`), now you can do say `myRef: { $all: true, myNestedRef: { $all: true } }`
2) excludes `reference` and `references` edge types from plain get `$all` usage, looks like in certain cases we still included the ids in the response by default, but we never do this in more advanced scenarios such as traversals/inherits/etc. so removed this behaviour for consistency