### PR TITLE
Optimize substring lookup

### DIFF
--- a/server/modules/selva/include/selva_object.h
+++ b/server/modules/selva/include/selva_object.h
@@ -255,7 +255,7 @@ int SelvaObject_SetUserMeta(struct SelvaObject *obj, const struct RedisModuleStr
 /**
  * @param flags Accepts SELVA_OBJECT_REPLY_SPLICE_FLAG and other reply flags.
  */
-int SelvaObject_GetWithWildcardStr(
+int SelvaObject_ReplyWithWildcardStr(
         struct RedisModuleCtx *ctx,
         struct RedisModuleString *lang,
         struct SelvaObject *obj,

--- a/server/modules/selva/lib/util/Makefile
+++ b/server/modules/selva/lib/util/Makefile
@@ -16,7 +16,7 @@ OBJS := \
 	mempool.o \
 	poptop.o \
 	queue_r.o \
-	strnstr.o \
+	strnstrn.o \
 	svector.o \
 	trx.o
 ifeq ($(uname_S),Darwin) # macOS

--- a/server/modules/selva/lib/util/cstrings.h
+++ b/server/modules/selva/lib/util/cstrings.h
@@ -21,7 +21,7 @@ size_t substring_count(const char *string, const char *substring, size_t n);
  * Find the first occurrence of find in s, where the search is limited to the
  * first slen characters of s.
  */
-char * strnstr(const char *s, const char *find, size_t slen);
+char * strnstrn(const char *s, size_t s_len, const char *find, size_t find_len);
 
 int get_array_field_index(const char *field_str, size_t field_len, ssize_t *res);
 

--- a/server/modules/selva/lib/util/strnstrn.c
+++ b/server/modules/selva/lib/util/strnstrn.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2021 SAULX
+ * Copyright (c) 2021-2022 SAULX
  * Copyright (c) 2015 Olli Vanhoja <olli.vanhoja@cs.helsinki.fi>
  * Copyright (c) 2001 Mike Barcroft <mike@FreeBSD.org>
  * Copyright (c) 1990, 1993
@@ -36,28 +36,29 @@
  */
 
 #include <string.h>
+#include "cdefs.h"
 
-char * strnstr(const char *s, const char *find, size_t slen)
+__hot char * strnstrn(const char *s, size_t s_len, const char *find, size_t find_len)
 {
     char c;
 
-    if ((c = *find++) != '\0') {
-        size_t len = strlen(find);
+    if (likely(find_len > 0 && (c = *find++) != '\0')) {
+        find_len--;
 
         do {
             char sc;
 
             do {
-                if (slen-- < 1 || (sc = *s++) == '\0') {
+                if (s_len-- < 1 || (sc = *s++) == '\0') {
                     return NULL;
                 }
             } while (sc != c);
 
-            if (len > slen) {
+            if (find_len > s_len) {
                 return NULL;
             }
 
-        } while (strncmp(s, find, len) != 0);
+        } while (strncmp(s, find, find_len) != 0);
         s--;
     }
 

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -164,7 +164,7 @@ static int send_edge_field(
     size_t next_prefix_len;
 
     if (field_prefix_str) {
-        const char *s = strnstr(field_str, ".", field_len);
+        const char *s = strnstrn(field_str, field_len, ".", 1);
         const int n = s ? (int)(s - field_str) + 1 : (int)field_len;
         const RedisModuleString *next_prefix;
 
@@ -274,6 +274,7 @@ static int send_node_field(
      */
     if (strstr(field_str, ".*.")) {
         long resp_count = 0;
+
         err = SelvaObject_GetWithWildcardStr(ctx, lang, obj, field_str, field_len, &resp_count, -1, SELVA_OBJECT_REPLY_BINUMF_FLAG);
         if (err && err != SELVA_ENOENT) {
             fprintf(stderr, "%s:%d: Sending wildcard field %.*s of %.*s failed: %s\n",

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -275,7 +275,7 @@ static int send_node_field(
     if (strstr(field_str, ".*.")) {
         long resp_count = 0;
 
-        err = SelvaObject_GetWithWildcardStr(ctx, lang, obj, field_str, field_len, &resp_count, -1, SELVA_OBJECT_REPLY_BINUMF_FLAG);
+        err = SelvaObject_ReplyWithWildcardStr(ctx, lang, obj, field_str, field_len, &resp_count, -1, SELVA_OBJECT_REPLY_BINUMF_FLAG);
         if (err && err != SELVA_ENOENT) {
             fprintf(stderr, "%s:%d: Sending wildcard field %.*s of %.*s failed: %s\n",
                     __FILE__, __LINE__,
@@ -482,7 +482,7 @@ static int send_array_object_field(
     if (strstr(field_str, ".*.")) {
         long resp_count = 0;
 
-        err = SelvaObject_GetWithWildcardStr(ctx, lang, obj, field_str, field_len, &resp_count, -1, SELVA_OBJECT_REPLY_BINUMF_FLAG);
+        err = SelvaObject_ReplyWithWildcardStr(ctx, lang, obj, field_str, field_len, &resp_count, -1, SELVA_OBJECT_REPLY_BINUMF_FLAG);
         if (err && err != SELVA_ENOENT) {
             fprintf(stderr, "%s:%d: Sending wildcard field %.*s in array object failed: %s\n",
                     __FILE__, __LINE__,

--- a/server/modules/selva/module/selva_object/selva_object.c
+++ b/server/modules/selva/module/selva_object/selva_object.c
@@ -2218,7 +2218,7 @@ int SelvaObject_ReplyWithObject(
     }
 }
 
-int SelvaObject_GetWithWildcardStr(
+int SelvaObject_ReplyWithWildcardStr(
         RedisModuleCtx *ctx,
         RedisModuleString *lang,
         struct SelvaObject *obj,
@@ -2230,8 +2230,12 @@ int SelvaObject_GetWithWildcardStr(
     const size_t idx = strnstrn(okey_str, okey_len, ".*.", 3) - okey_str + 1; /* .*. => *. */
 
     if (idx > SELVA_OBJECT_KEY_MAX) {
-        /* Assume strnstrn() returned the NULL pointer. */
-        return SELVA_EINVAL;
+        /*
+         * Assume strnstrn() returned the NULL pointer.
+         * The error here matches what get_key() would send,
+         * thus not introducing a new error code.
+         */
+        return SELVA_ENAMETOOLONG;
     }
 
     /* Path before the wildcard character. */
@@ -2270,10 +2274,10 @@ int SelvaObject_GetWithWildcardStr(
 
             if (strnstrn(new_field, new_field_len, ".*.", 3)) {
                 /* Recurse for nested wildcards while keeping the resolved path. */
-                SelvaObject_GetWithWildcardStr(ctx, lang, obj, new_field, new_field_len,
-                                               resp_count,
-                                               resp_path_start_idx == -1 ? idx : resp_path_start_idx,
-                                               flags);
+                SelvaObject_ReplyWithWildcardStr(ctx, lang, obj, new_field, new_field_len,
+                                                 resp_count,
+                                                 resp_path_start_idx == -1 ? idx : resp_path_start_idx,
+                                                 flags);
                 continue;
             }
 

--- a/server/modules/selva/module/selva_object/selva_object.c
+++ b/server/modules/selva/module/selva_object/selva_object.c
@@ -670,7 +670,7 @@ static int get_key(struct SelvaObject *obj, const char *key_name_str, size_t key
         return SELVA_ENAMETOOLONG;
     }
 
-    if (strnstr(key_name_str, ".", key_name_len)) {
+    if (strnstrn(key_name_str, key_name_len, ".", 1)) {
         return get_key_obj(obj, key_name_str, key_name_len, flags, out);
     }
 
@@ -2227,7 +2227,12 @@ int SelvaObject_GetWithWildcardStr(
         long *resp_count,
         int resp_path_start_idx,
         unsigned int flags) {
-    const size_t idx = strnstr(okey_str, ".*.", okey_len) - okey_str + 1; /* .*. => *. */
+    const size_t idx = strnstrn(okey_str, okey_len, ".*.", 3) - okey_str + 1; /* .*. => *. */
+
+    if (idx > SELVA_OBJECT_KEY_MAX) {
+        /* Assume strnstrn() returned the NULL pointer. */
+        return SELVA_EINVAL;
+    }
 
     /* Path before the wildcard character. */
     const size_t before_len = idx - 1;
@@ -2263,7 +2268,7 @@ int SelvaObject_GetWithWildcardStr(
                     (int)obj_key_len, obj_key_name_str,
                     (int)after_len, after);
 
-            if (strnstr(new_field, ".*.", new_field_len)) {
+            if (strnstrn(new_field, new_field_len, ".*.", 3)) {
                 /* Recurse for nested wildcards while keeping the resolved path. */
                 SelvaObject_GetWithWildcardStr(ctx, lang, obj, new_field, new_field_len,
                                                resp_count,

--- a/server/modules/selva/module/selva_object/selva_object_commands.c
+++ b/server/modules/selva/module/selva_object/selva_object_commands.c
@@ -129,8 +129,9 @@ int SelvaObject_GetCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
             long resp_count = 0;
 
             RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-            err = SelvaObject_GetWithWildcardStr(ctx, lang, obj, okey_str, okey_len,
-                                                 &resp_count, -1, SELVA_OBJECT_REPLY_SPLICE_FLAG | SELVA_OBJECT_REPLY_BINUMF_FLAG);
+            err = SelvaObject_ReplyWithWildcardStr(ctx, lang, obj, okey_str, okey_len,
+                                                   &resp_count, -1,
+                                                   SELVA_OBJECT_REPLY_SPLICE_FLAG | SELVA_OBJECT_REPLY_BINUMF_FLAG);
             if (err == SELVA_ENOENT) {
                 /* Keep looking. */
                 RedisModule_ReplySetArrayLength(ctx, resp_count);


### PR DESCRIPTION
Turn `strnstr()` into a new function called `strnstrn()` that
avoids finding the length of the find string because it seems
to be a rather hot part of the code.

`strnstrn()` seems to benefit from being marked as a hot
function, at least for now. Eventually instruction cache
optimizations will break because all the hot functions
can't fit the cache lines nor be close enough to each
other when needed. Perhaps in the future we should determine
which hot functions are commonly used together and create
more specific hot sections in the elf.