### PR TITLE
Replicate automatic timestamps correctly

### DIFF
--- a/client/test/createdAt.ts
+++ b/client/test/createdAt.ts
@@ -484,3 +484,41 @@ test.serial('automatic child creation and timestamps', async (t) => {
 
   await client.destroy()
 })
+
+test.serial('createdAt can be modified', async (t) => {
+  const client = connect({
+    port,
+  })
+
+  const before = Date.now()
+  const person = await client.set({
+    $language: 'en',
+    type: 'person',
+    title: 'yesh',
+  })
+  await wait(2)
+  const after = Date.now()
+
+  let result = await client.get({
+    $id: person,
+    createdAt: true,
+  })
+
+  let createdAt = result.createdAt
+  t.true(createdAt <= after && createdAt >= before)
+
+  await client.set({
+    $id: person,
+    createdAt: 1000,
+  })
+  result = await client.get({
+    $id: person,
+    createdAt: true,
+  })
+
+  createdAt = result.createdAt
+  t.deepEqual(createdAt, 1000)
+
+  await client.delete('root')
+  await client.destroy()
+})

--- a/server/modules/selva/tunables.h
+++ b/server/modules/selva/tunables.h
@@ -13,6 +13,12 @@
  */
 #define MEM_DEBUG 1
 
+/**
+ * Add delay to the replication of the Modify command.
+ * Unit is nanoseconds. Normally this should be set to 0.
+ */
+#define DEBUG_MODIFY_REPLICATION_DELAY_NS 0
+
 /*
  * SVector tunables.
  */


### PR DESCRIPTION
`createdAt` and `updatedAt` must be replicated as is and the
replicas must not modify those timestamps.