### PR TITLE
Allow custom/proper aligment of mempool objects

### DIFF
--- a/server/modules/selva/lib/util/mempool.c
+++ b/server/modules/selva/lib/util/mempool.c
@@ -60,9 +60,9 @@ void mempool_init(struct mempool *mempool, size_t slab_size, size_t obj_size, si
     assert(obj_size < UINT16_MAX);
     assert(obj_align < UINT16_MAX);
 
-    mempool->slab_size_kb = slab_size / 1024;
-    mempool->obj_size = obj_size;
-    mempool->obj_align = obj_align;
+    mempool->slab_size_kb = (typeof(mempool->slab_size_kb))(slab_size / 1024);
+    mempool->obj_size = (typeof(mempool->obj_size))(obj_size);
+    mempool->obj_align = (typeof(mempool->obj_align))(obj_align);
     SLIST_INIT(&mempool->slabs);
     LIST_INIT(&mempool->free_objects);
 }

--- a/server/modules/selva/lib/util/mempool.h
+++ b/server/modules/selva/lib/util/mempool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 SAULX
+ * Copyright (c) 2020-2022 SAULX
  * SPDX-License-Identifier: MIT
  */
 #pragma once
@@ -33,7 +33,8 @@ struct mempool_slab {
  * A structure describing a memory pool.
  */
 struct mempool {
-    uint32_t slab_size;
+    uint16_t slab_size_kb;
+    uint16_t obj_align;
     uint32_t obj_size;
     SLIST_HEAD(mempool_slab_list, mempool_slab) slabs;
     LIST_HEAD(mempool_free_object_list, mempool_object) free_objects;
@@ -41,8 +42,10 @@ struct mempool {
 
 /**
  * Initialize a new mempool slab allocator.
+ * @param slab_size is the size of a single slab.
+ * @param obj_size is the size of a single object stored in a slab.
  */
-void mempool_init(struct mempool *mempool, size_t slab_size, size_t obj_size);
+void mempool_init(struct mempool *mempool, size_t slab_size, size_t obj_size, size_t obj_align);
 
 /**
  * Destroy a mempool and free all memory.

--- a/server/modules/selva/lib/util/mempool.h
+++ b/server/modules/selva/lib/util/mempool.h
@@ -10,24 +10,24 @@
 #include "queue.h"
 
 /**
- * A structure describing the object allocation unit.
- */
-struct mempool_object {
-    struct mempool_slab *slab; /*!< A pointer back the slab. */
-    /**
-     * A list entry pointing to the next free object if this object is in the
-     * free list.
-     */
-    LIST_ENTRY(mempool_object) next_free;
-} __attribute__((aligned(sizeof(size_t))));
-
-/**
  * A structure describing a slab in the pool allocator.
  */
 struct mempool_slab {
     size_t nr_free;
     SLIST_ENTRY(mempool_slab) next_slab;
-} __attribute__((aligned((sizeof(size_t)))));
+} __attribute__((aligned((16)))); /* max_align_t would be better. */
+
+/**
+ * A structure describing a chunk allocation.
+ */
+struct mempool_chunk {
+    struct mempool_slab *slab; /*!< A pointer back the slab. */
+    /**
+     * A list entry pointing to the next free chunk if this object is in the
+     * free list.
+     */
+    LIST_ENTRY(mempool_chunk) next_free;
+} __attribute__((aligned(sizeof(size_t))));
 
 /**
  * A structure describing a memory pool.
@@ -37,7 +37,7 @@ struct mempool {
     uint16_t obj_align;
     uint32_t obj_size;
     SLIST_HEAD(mempool_slab_list, mempool_slab) slabs;
-    LIST_HEAD(mempool_free_object_list, mempool_object) free_objects;
+    LIST_HEAD(mempool_free_chunk_list, mempool_chunk) free_chunks;
 };
 
 /**

--- a/server/modules/selva/lib/util/svector.c
+++ b/server/modules/selva/lib/util/svector.c
@@ -1,8 +1,9 @@
 /*
- * Copyright (c) 2020-2021 SAULX
+ * Copyright (c) 2020-2022 SAULX
  * SPDX-License-Identifier: MIT
  */
 #include <assert.h>
+#include <stdalign.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -62,7 +63,7 @@ SVector *SVector_Init(SVector *vec, size_t initial_len, int (*compar)(const void
         } else {
             vec->vec_mode = SVECTOR_MODE_RBTREE;
             RB_INIT(&vec->vec_rbhead);
-            mempool_init(&vec->vec_rbmempool, SVECTOR_SLAB_SIZE, sizeof(struct SVector_rbnode));
+            mempool_init(&vec->vec_rbmempool, SVECTOR_SLAB_SIZE, sizeof(struct SVector_rbnode), alignof(struct SVector_rbnode));
         }
     }
 
@@ -128,7 +129,7 @@ static void migrate_arr_to_rbtree(SVector *vec) {
     void **vec_arr = vec->vec_arr;
 
     RB_INIT(&vec->vec_rbhead);
-    mempool_init(&vec->vec_rbmempool, SVECTOR_SLAB_SIZE, sizeof(struct SVector_rbnode));
+    mempool_init(&vec->vec_rbmempool, SVECTOR_SLAB_SIZE, sizeof(struct SVector_rbnode), alignof(struct SVector_rbnode));
 
     void **pp;
     for (typeof(pp) pp_end = (typeof(pp))vec_arr + vec_last, pp = (typeof(pp))vec_arr;

--- a/server/modules/selva/test/units/test-mempool.c
+++ b/server/modules/selva/test/units/test-mempool.c
@@ -1,4 +1,5 @@
 #include <punit.h>
+#include <stdalign.h>
 #include <stdint.h>
 #include "mempool.h"
 
@@ -16,7 +17,7 @@ static char * test_simple_allocs(void)
     const size_t obj_size = 256;
     struct mempool pool;
 
-    mempool_init(&pool, slab_size, obj_size);
+    mempool_init(&pool, slab_size, obj_size, alignof(size_t));
 
     char *p1 = mempool_get(&pool);
     snprintf(p1, obj_size, "Hello world\n");
@@ -41,7 +42,7 @@ static char * test_object_reuse(void)
     const size_t obj_size = 256;
     struct mempool pool;
 
-    mempool_init(&pool, slab_size, obj_size);
+    mempool_init(&pool, slab_size, obj_size, alignof(size_t));
 
     char *p1 = mempool_get(&pool);
     (void)mempool_get(&pool);
@@ -63,14 +64,14 @@ static char * test_gc(void)
     const size_t obj_size = 256;
     struct mempool pool;
 
-    mempool_init(&pool, slab_size, obj_size);
+    mempool_init(&pool, slab_size, obj_size, alignof(size_t));
 
     char *p1 = mempool_get(&pool);
     mempool_return(&pool, p1);
     mempool_gc(&pool);
 
     struct mempool pool2;
-    mempool_init(&pool2, slab_size, obj_size);
+    mempool_init(&pool2, slab_size, obj_size, alignof(size_t));
     pu_assert("The second pool works", mempool_get(&pool2));
 
     char *p2 = mempool_get(&pool);
@@ -85,12 +86,12 @@ static char * test_gc(void)
 
 static char * test_allocs(void)
 {
-    const size_t slab_size = 512;
+    const size_t slab_size = 1024;
     const size_t obj_size = 100;
     struct mempool pool;
     char *p;
 
-    mempool_init(&pool, slab_size, obj_size);
+    mempool_init(&pool, slab_size, obj_size, 1);
 
     p = mempool_get(&pool);
     pu_assert("got obj", p);


### PR DESCRIPTION
In some cases mempool might align objects incorrectly. Ensure
that the chunks are always aligned properly and allow passing the
proper alignment of the object type.