### PR TITLE
Fix sign mixing in ReplyWithWildcardStr()

### DIFF
--- a/server/modules/selva/module/selva_object/selva_object.c
+++ b/server/modules/selva/module/selva_object/selva_object.c
@@ -2243,7 +2243,7 @@ int SelvaObject_ReplyWithWildcardStr(
         long *resp_count,
         int resp_path_start_idx,
         unsigned int flags) {
-    const size_t idx = strnstrn(okey_str, okey_len, ".*.", 3) - okey_str + 1; /* .*. => *. */
+    const int idx = (int)(strnstrn(okey_str, okey_len, ".*.", 3) - okey_str + 1); /* .*. => *. */
 
     if (idx > SELVA_OBJECT_KEY_MAX) {
         /*


### PR DESCRIPTION
```
module/selva_object/selva_object.c:2295:84: warning: operand of ‘?:’
changes signedness from ‘int’ to ‘size_t’ {aka ‘const long unsigned
int’} due to unsignedness of other operand [-Wsign-compare]
 2295 |
      resp_path_start_idx == -1 ? idx : resp_path_start_idx,
      |
^~~~~~~~~~~~~~~~~~~
```