### PR TITLE
Fix SelvaObject_GetArrayLen

### DIFF
--- a/server/modules/selva/module/selva_object/selva_object.c
+++ b/server/modules/selva/module/selva_object/selva_object.c
@@ -1581,7 +1581,7 @@ size_t SelvaObject_GetArrayLenStr(struct SelvaObject *obj, const char *key_name_
         return 0;
     }
 
-    return vec->vec_last;
+    return SVector_Size(vec);
 }
 
 size_t SelvaObject_GetArrayLen(struct SelvaObject *obj, const RedisModuleString *key_name) {


### PR DESCRIPTION
`SelvaObject_GetArrayLen()` and `SelvaObject_GetArrayLenStr()`
should return the size using `SVector_Size()` to account for
any offset in the array.