### PR TITLE
Pass hierarchy to the RPN context

### DIFF
--- a/server/modules/selva/include/rpn.h
+++ b/server/modules/selva/include/rpn.h
@@ -28,13 +28,15 @@ enum rpn_error {
 struct RedisModuleCtx;
 struct RedisModuleKey;
 struct RedisModuleString;
-struct SelvaSet;
+struct SelvaHierarchy;
 struct SelvaHierarchyNode;
+struct SelvaSet;
 struct rpn_operand;
 
 struct rpn_ctx {
     int depth;
     int nr_reg;
+    struct SelvaHierarchy *hierarchy;
     const struct SelvaHierarchyNode *node; /*!< A pointer to the current hierarchy node set with rpn_set_hierarchy_node(). */
     struct SelvaObject *obj; /*!< Selva object of the current node. */
     struct RedisModuleString *rms_field;  /*!< This holds the name of the currently accessed field. */
@@ -67,7 +69,8 @@ void rpn_destroy(struct rpn_ctx *ctx);
  * An operand requiring a node pointer will return RPN_ERR_ILLOPN if the pointer
  * is not set.
  */
-static inline void rpn_set_hierarchy_node(struct rpn_ctx *ctx, const struct SelvaHierarchyNode *node) {
+static inline void rpn_set_hierarchy_node(struct rpn_ctx *ctx, struct SelvaHierarchy *hierarchy, const struct SelvaHierarchyNode *node) {
+    ctx->hierarchy = hierarchy;
     ctx->node = node;
 }
 

--- a/server/modules/selva/include/subscriptions.h
+++ b/server/modules/selva/include/subscriptions.h
@@ -345,7 +345,11 @@ void SelvaSubscriptions_ClearAllMarkers(
  * @param node is a pointer to the node the filter should be executed against.
  * @param marker is a pointer to the subscription marker.
  */
-int Selva_SubscriptionFilterMatch(struct RedisModuleCtx *ctx, const struct SelvaHierarchyNode *node, struct Selva_SubscriptionMarker *marker);
+int Selva_SubscriptionFilterMatch(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        const struct SelvaHierarchyNode *node,
+        struct Selva_SubscriptionMarker *marker);
 
 /**
  * Destroy all deferred events.

--- a/server/modules/selva/module/aggregate.c
+++ b/server/modules/selva/module/aggregate.c
@@ -213,7 +213,7 @@ static int AggregateCommand_NodeCb(struct SelvaHierarchyNode *node, void *arg) {
 
         /* Set node_id to the register */
         rpn_set_reg(rpn_ctx, 0, nodeId, SELVA_NODE_ID_SIZE, RPN_SET_REG_FLAG_IS_NAN);
-        rpn_set_hierarchy_node(rpn_ctx, node);
+        rpn_set_hierarchy_node(rpn_ctx, args->find_args.hierarchy, node);
         rpn_set_obj(rpn_ctx, SelvaHierarchy_GetNodeObject(node));
 
         /*
@@ -702,7 +702,7 @@ int SelvaHierarchy_AggregateCommand(RedisModuleCtx *ctx, RedisModuleString **arg
         .aggregation_result_int = 0,
         .aggregation_result_double = initial_double_val,
         .item_count = 0,
-        /* .find_args = find_args */
+        /* .hierarchyfind_args = find_args */
     };
 
     ssize_t nr_nodes = 0;
@@ -789,7 +789,8 @@ int SelvaHierarchy_AggregateCommand(RedisModuleCtx *ctx, RedisModuleString **arg
             .find_args = {
                 /* we always need context. */
                 .ctx = ctx,
-                .send_param.fields = fields
+                .hierarchy = hierarchy,
+                .send_param.fields = fields,
             }
         };
 
@@ -1048,6 +1049,7 @@ int SelvaHierarchy_AggregateInCommand(RedisModuleCtx *ctx, RedisModuleString **a
             .find_args = {
                 /* we always need context */
                 .ctx = ctx,
+                .hierarchy = hierarchy,
                 .send_param.fields = fields,
                 .send_param.excluded_fields = NULL,
             }

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -934,6 +934,7 @@ static int send_node_object_merge(
 
 static int exec_fields_expression(
         struct RedisModuleCtx *redis_ctx,
+        struct SelvaHierarchy *hierarchy,
         const struct SelvaHierarchyNode *node,
         struct rpn_ctx *rpn_ctx,
         const struct rpn_expression *expr,
@@ -946,7 +947,7 @@ static int exec_fields_expression(
 
     SelvaHierarchy_GetNodeId(nodeId, node);
     rpn_set_reg(rpn_ctx, 0, nodeId, SELVA_NODE_ID_SIZE, RPN_SET_REG_FLAG_IS_NAN);
-    rpn_set_hierarchy_node(rpn_ctx, node);
+    rpn_set_hierarchy_node(rpn_ctx, hierarchy, node);
     rpn_set_obj(rpn_ctx, SelvaHierarchy_GetNodeObject(node));
 
     SelvaSet_Init(&set, SELVA_SET_TYPE_RMSTRING);
@@ -993,7 +994,7 @@ static int print_node(
         if (!fields) {
             err = SELVA_ENOMEM;
         } else {
-            err = exec_fields_expression(ctx, node, args->fields_rpn_ctx, args->fields_expression, fields);
+            err = exec_fields_expression(ctx, hierarchy, node, args->fields_rpn_ctx, args->fields_expression, fields);
             if (!err) {
                 err = send_node_fields(ctx, lang, hierarchy, node, fields, args->excluded_fields);
             }
@@ -1023,7 +1024,7 @@ static __hot int FindCommand_NodeCb(struct SelvaHierarchyNode *node, void *arg) 
 
         /* Set node_id to the register */
         rpn_set_reg(rpn_ctx, 0, nodeId, SELVA_NODE_ID_SIZE, RPN_SET_REG_FLAG_IS_NAN);
-        rpn_set_hierarchy_node(rpn_ctx, node);
+        rpn_set_hierarchy_node(rpn_ctx, args->hierarchy, node);
         rpn_set_obj(rpn_ctx, SelvaHierarchy_GetNodeObject(node));
 
         /*

--- a/server/modules/selva/module/find_index/find_index.c
+++ b/server/modules/selva/module/find_index/find_index.c
@@ -280,7 +280,7 @@ static void update_index(
             SelvaSet_Init(&icb->res, SELVA_SET_TYPE_NODEID);
         }
 
-        if (Selva_SubscriptionFilterMatch(ctx, node, marker)) {
+        if (Selva_SubscriptionFilterMatch(ctx, hierarchy, node, marker)) {
             Selva_NodeId node_id;
 
             SelvaHierarchy_GetNodeId(node_id, node);
@@ -299,7 +299,7 @@ static void update_index(
          * deleting and adding a node. However, we know that currently deleting
          * a node will cause also a SELVA_SUBSCRIPTION_FLAG_CL_HIERARCHY event.
          */
-        if (icb->flags.valid && Selva_SubscriptionFilterMatch(ctx, node, marker)) {
+        if (icb->flags.valid && Selva_SubscriptionFilterMatch(ctx, hierarchy, node, marker)) {
             Selva_NodeId node_id;
 
             SelvaHierarchy_GetNodeId(node_id, node);

--- a/server/modules/selva/module/hierarchy/hierarchy.c
+++ b/server/modules/selva/module/hierarchy/hierarchy.c
@@ -1965,6 +1965,7 @@ static SVector *get_adj_vec(SelvaHierarchyNode *node, const char *field_str, siz
  */
 static int exec_edge_filter(
         struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
         struct rpn_ctx *edge_filter_ctx,
         const struct rpn_expression *edge_filter,
         const SVector *adj_vec,
@@ -1988,7 +1989,7 @@ static int exec_edge_filter(
         int res;
 
         rpn_set_reg(edge_filter_ctx, 0, node->id, SELVA_NODE_ID_SIZE, RPN_SET_REG_FLAG_IS_NAN);
-        rpn_set_hierarchy_node(edge_filter_ctx, node);
+        rpn_set_hierarchy_node(edge_filter_ctx, hierarchy, node);
         rpn_set_obj(edge_filter_ctx, edge_metadata);
 
         rpn_err = rpn_bool(ctx, edge_filter_ctx, edge_filter, &res); /* TODO Handle RPN errors. */
@@ -2082,7 +2083,7 @@ static int bfs_expression(
         SelvaSet_Init(&fields, SELVA_SET_TYPE_RMSTRING);
 
         rpn_set_reg(rpn_ctx, 0, node->id, SELVA_NODE_ID_SIZE, RPN_SET_REG_FLAG_IS_NAN);
-        rpn_set_hierarchy_node(rpn_ctx, node);
+        rpn_set_hierarchy_node(rpn_ctx, hierarchy, node);
         rpn_set_obj(rpn_ctx, SelvaHierarchy_GetNodeObject(node));
         rpn_err = rpn_selvaset(redis_ctx, rpn_ctx, rpn_expr, &fields);
         if (rpn_err) {
@@ -2118,7 +2119,7 @@ static int bfs_expression(
                  */
                 if (field_type == SELVA_HIERARCHY_TRAVERSAL_EDGE_FIELD && edge_filter &&
                     !Trx_HasVisited(&trx_cur, &adj->trx_label) && /* skip if already visited. */
-                    !exec_edge_filter(redis_ctx, edge_filter_ctx, edge_filter, adj_vec, adj)) {
+                    !exec_edge_filter(redis_ctx, hierarchy, edge_filter_ctx, edge_filter, adj_vec, adj)) {
                     continue;
                 }
 
@@ -2378,7 +2379,7 @@ int SelvaHierarchy_TraverseExpression(
     SelvaSet_Init(&fields, SELVA_SET_TYPE_RMSTRING);
 
     rpn_set_reg(rpn_ctx, 0, head->id, SELVA_NODE_ID_SIZE, RPN_SET_REG_FLAG_IS_NAN);
-    rpn_set_hierarchy_node(rpn_ctx, head);
+    rpn_set_hierarchy_node(rpn_ctx, hierarchy, head);
     rpn_set_obj(rpn_ctx, SelvaHierarchy_GetNodeObject(head));
     rpn_err = rpn_selvaset(ctx, rpn_ctx, rpn_expr, &fields);
     if (rpn_err) {
@@ -2413,7 +2414,7 @@ int SelvaHierarchy_TraverseExpression(
              */
             if (field_type == SELVA_HIERARCHY_TRAVERSAL_EDGE_FIELD && edge_filter &&
                 !Trx_HasVisited(&trx_cur, &adj->trx_label) && /* skip if already visited. */
-                !exec_edge_filter(ctx, edge_filter_ctx, edge_filter, adj_vec, adj)) {
+                !exec_edge_filter(ctx, hierarchy, edge_filter_ctx, edge_filter, adj_vec, adj)) {
                 continue;
             }
 


### PR DESCRIPTION
Many hierarchy functions require a pointer to the hierarchy in
addition to a node pointer.