### PR TITLE
Support RPN `has` function for all set-like fields

### DIFF
--- a/query-ast-parser/src/ast2rpn.ts
+++ b/query-ast-parser/src/ast2rpn.ts
@@ -140,7 +140,9 @@ export default function ast2rpn(
         out += ` ${valueId} $${fieldId} g ${op}`
       } else if (vType === 'number') {
         out += ` @${valueId} $${fieldId} g ${op}`
-      } else {
+      } else if (vType == 'string' && f.$operator == 'has') {
+        out += ` $${valueId} $${fieldId} ${op}`
+      } else { // Assume we can read the field as a string.
         out += ` $${valueId} $${fieldId} f ${op}`
       }
     } else if (vType == 'boolean') {

--- a/server/modules/selva/Makefile
+++ b/server/modules/selva/Makefile
@@ -17,6 +17,7 @@ OBJS := \
 	module/errors.o \
 	module/find.o \
 	module/find_index/find_index.o \
+	module/hierarchy/field_set.o \
 	module/hierarchy/hierarchy.o \
 	module/hierarchy/hierarchy_detached.o \
 	module/hierarchy/hierarchy_reply.o \

--- a/server/modules/selva/include/hierarchy.h
+++ b/server/modules/selva/include/hierarchy.h
@@ -452,6 +452,10 @@ static inline int SelvaHierarchy_NodeExists(SelvaHierarchy *hierarchy, const Sel
  */
 ssize_t SelvaModify_GetHierarchyHeads(SelvaHierarchy *hierarchy, Selva_NodeId **res);
 
+void SelvaHierarchy_TraverseChildren(struct SelvaHierarchyNode *node, const struct SelvaHierarchyCallback *cb);
+void SelvaHierarchy_TraverseParents(struct SelvaHierarchyNode *node, const struct SelvaHierarchyCallback *cb);
+int SelvaHierarchy_TraverseBFSAncestors(SelvaHierarchy *hierarchy, struct SelvaHierarchyNode *node, const struct SelvaHierarchyCallback *cb);
+int SelvaHierarchy_TraverseBFSDescendants(SelvaHierarchy *hierarchy, struct SelvaHierarchyNode *node, const struct SelvaHierarchyCallback *cb);
 int SelvaHierarchy_Traverse(
         SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
@@ -497,6 +501,23 @@ int SelvaHierarchy_TraverseArray(
 int SelvaHierarchy_TraverseSet(
         SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
+        const char *field_str,
+        size_t field_len,
+        const struct SelvaObjectSetForeachCallback *cb);
+/**
+ * Foreach value in a set-like field.
+ * Traverse each value (foreach) in a field.
+ * Supported fields:
+ * - parents
+ * - children
+ * - ancestors
+ * - descendants
+ * - string and numeric array fields
+ * - string and numeric set fields
+ */
+int SelvaHierarchy_ForeachInField(
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
         const char *field_str,
         size_t field_len,
         const struct SelvaObjectSetForeachCallback *cb);

--- a/server/modules/selva/include/rpn.h
+++ b/server/modules/selva/include/rpn.h
@@ -37,7 +37,7 @@ struct rpn_ctx {
     int depth;
     int nr_reg;
     struct SelvaHierarchy *hierarchy;
-    const struct SelvaHierarchyNode *node; /*!< A pointer to the current hierarchy node set with rpn_set_hierarchy_node(). */
+    struct SelvaHierarchyNode *node; /*!< A pointer to the current hierarchy node set with rpn_set_hierarchy_node(). */
     struct SelvaObject *obj; /*!< Selva object of the current node. */
     struct RedisModuleString *rms_field;  /*!< This holds the name of the currently accessed field. */
     struct rpn_operand **reg;
@@ -69,7 +69,7 @@ void rpn_destroy(struct rpn_ctx *ctx);
  * An operand requiring a node pointer will return RPN_ERR_ILLOPN if the pointer
  * is not set.
  */
-static inline void rpn_set_hierarchy_node(struct rpn_ctx *ctx, struct SelvaHierarchy *hierarchy, const struct SelvaHierarchyNode *node) {
+static inline void rpn_set_hierarchy_node(struct rpn_ctx *ctx, struct SelvaHierarchy *hierarchy, struct SelvaHierarchyNode *node) {
     ctx->hierarchy = hierarchy;
     ctx->node = node;
 }

--- a/server/modules/selva/include/subscriptions.h
+++ b/server/modules/selva/include/subscriptions.h
@@ -124,7 +124,7 @@ typedef void Selva_SubscriptionMarkerAction(
         struct SelvaHierarchy *hierarchy,
         struct Selva_SubscriptionMarker *marker,
         unsigned short event_flags,
-        const struct SelvaHierarchyNode *node);
+        struct SelvaHierarchyNode *node);
 
 /**
  * Subscription marker.
@@ -348,7 +348,7 @@ void SelvaSubscriptions_ClearAllMarkers(
 int Selva_SubscriptionFilterMatch(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         struct Selva_SubscriptionMarker *marker);
 
 /**
@@ -399,19 +399,19 @@ void SelvaSubscriptions_DeferMissingAccessorEvents(struct SelvaHierarchy *hierar
 void SelvaSubscriptions_DeferHierarchyEvents(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node);
+        struct SelvaHierarchyNode *node);
 void SelvaSubscriptions_DeferHierarchyDeletionEvents(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node);
+        struct SelvaHierarchyNode *node);
 void SelvaSubscriptions_FieldChangePrecheck(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node);
+        struct SelvaHierarchyNode *node);
 void SelvaSubscriptions_DeferFieldChangeEvents(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         const char *field_str,
         size_t field_len);
 void SelvaSubscriptions_DeferAliasChangeEvents(
@@ -421,7 +421,7 @@ void SelvaSubscriptions_DeferAliasChangeEvents(
 void SelvaSubscriptions_DeferTriggerEvents(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         enum Selva_SubscriptionTriggerType event_type);
 void SelvaSubscriptions_SendDeferredEvents(struct SelvaHierarchy *hierarchy);
 

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -935,7 +935,7 @@ static int send_node_object_merge(
 static int exec_fields_expression(
         struct RedisModuleCtx *redis_ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         struct rpn_ctx *rpn_ctx,
         const struct rpn_expression *expr,
         struct SelvaObject *fields) {

--- a/server/modules/selva/module/find_index/find_index.c
+++ b/server/modules/selva/module/find_index/find_index.c
@@ -239,7 +239,7 @@ static void update_index(
         struct SelvaHierarchy *hierarchy __unused,
         struct Selva_SubscriptionMarker *marker,
         unsigned short event_flags,
-        const struct SelvaHierarchyNode *node) {
+        struct SelvaHierarchyNode *node) {
     struct SelvaFindIndexControlBlock *icb;
 
     /*

--- a/server/modules/selva/module/hierarchy/field_set.c
+++ b/server/modules/selva/module/hierarchy/field_set.c
@@ -1,0 +1,151 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/types.h>
+#include "selva.h"
+#include "errors.h"
+#include "selva_object.h"
+#include "hierarchy.h"
+
+struct field_name {
+    const char * const name;
+    size_t len;
+};
+
+#define UNSUP(fname) \
+    { .name = fname, .len = sizeof(fname) - 1 }
+
+static const struct field_name unsupported_fields[] = {
+    UNSUP(SELVA_ID_FIELD),
+    UNSUP(SELVA_TYPE_FIELD),
+    UNSUP(SELVA_CREATED_AT_FIELD),
+    UNSUP(SELVA_UPDATED_AT_FIELD),
+};
+
+static int is_unsupported_field(const char *field_str, size_t field_len) {
+    for (size_t i = 0; i < num_elem(unsupported_fields); i++) {
+        if (field_len == unsupported_fields[i].len && !memcmp(field_str, unsupported_fields[i].name, field_len)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int hierarchy_foreach_cb(struct SelvaHierarchyNode *node, void *arg) {
+    const struct SelvaObjectSetForeachCallback *cb = (struct SelvaObjectSetForeachCallback *)arg;
+    union SelvaObjectSetForeachValue svalue;
+
+    SelvaHierarchy_GetNodeId(svalue.node_id, node);
+    return cb->cb(svalue, SELVA_SET_TYPE_NODEID, cb->cb_arg);
+}
+
+static int array_foreach_cb_wrapper(union SelvaObjectArrayForeachValue value, enum SelvaObjectType subtype, void *arg) {
+    const struct SelvaObjectSetForeachCallback *cb = (struct SelvaObjectSetForeachCallback *)arg;
+    union SelvaObjectSetForeachValue svalue;
+
+    switch (subtype) {
+    case SELVA_OBJECT_DOUBLE:
+        svalue.d = value.d;
+        cb->cb(svalue, SELVA_SET_TYPE_DOUBLE, cb->cb_arg);
+        break;
+    case SELVA_OBJECT_LONGLONG:
+        svalue.ll = value.ll;
+        cb->cb(svalue, SELVA_SET_TYPE_LONGLONG, cb->cb_arg);
+        break;
+    case SELVA_OBJECT_STRING:
+        svalue.rms = value.rms;
+        cb->cb(svalue, SELVA_SET_TYPE_RMSTRING, cb->cb_arg);
+        break;
+    case SELVA_OBJECT_NULL:
+    case SELVA_OBJECT_OBJECT:
+    case SELVA_OBJECT_SET:
+    case SELVA_OBJECT_ARRAY:
+    case SELVA_OBJECT_POINTER:
+        return 1; /* Unsupported. */
+    }
+
+    return 0;
+}
+
+/**
+ * Foreach item in an array field.
+ */
+static int array_foreach(
+        struct SelvaObject *obj,
+        const char *field_str,
+        size_t field_len,
+        const struct SelvaObjectSetForeachCallback *cb) {
+    struct SelvaObjectArrayForeachCallback arr_cb = {
+        .cb = array_foreach_cb_wrapper,
+        .cb_arg = (void *)cb,
+    };
+
+    return SelvaObject_ArrayForeach(obj, field_str, field_len, &arr_cb);
+}
+
+int SelvaHierarchy_ForeachInField(
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        const char *field_str,
+        size_t field_len,
+        const struct SelvaObjectSetForeachCallback *cb) {
+#define IS_FIELD(name) \
+    (field_len == (sizeof(name) - 1) && !memcmp(field_str, name, sizeof(name) - 1))
+
+    if (IS_FIELD(SELVA_PARENTS_FIELD)) {
+        const struct SelvaHierarchyCallback hcb = {
+            .node_cb = hierarchy_foreach_cb,
+            .node_arg = (void *)cb,
+        };
+
+        SelvaHierarchy_TraverseParents(node, &hcb);
+        return 0;
+
+    } else if (IS_FIELD(SELVA_CHILDREN_FIELD)) {
+        const struct SelvaHierarchyCallback hcb = {
+            .node_cb = hierarchy_foreach_cb,
+            .node_arg = (void *)cb,
+        };
+
+        SelvaHierarchy_TraverseChildren(node, &hcb);
+        return 0;
+    } else if (IS_FIELD(SELVA_ANCESTORS_FIELD)) {
+        const struct SelvaHierarchyCallback hcb = {
+            .node_cb = hierarchy_foreach_cb,
+            .node_arg = (void *)cb,
+        };
+
+        return SelvaHierarchy_TraverseBFSAncestors(hierarchy, node, &hcb);
+    } else if (IS_FIELD(SELVA_DESCENDANTS_FIELD)) {
+        const struct SelvaHierarchyCallback hcb = {
+            .node_cb = hierarchy_foreach_cb,
+            .node_arg = (void *)cb,
+        };
+
+        return SelvaHierarchy_TraverseBFSDescendants(hierarchy, node, &hcb);
+    } else if (is_unsupported_field(field_str, field_len)) {
+        /* NOP */
+        /* TODO Edge */
+#if 0
+    } else if (is_edge_field()) {
+        /* TODO */
+#endif
+    } else {
+        /*
+         * Test if it's an array or set field. Note that SELVA_ALIASES_FIELD is
+         * just a regular SelvaSet.
+         */
+        struct SelvaObject *obj = SelvaHierarchy_GetNodeObject(node);
+        enum SelvaObjectType field_type;
+
+        field_type = SelvaObject_GetTypeStr(obj, field_str, field_len);
+        if (field_type == SELVA_OBJECT_SET) {
+            return SelvaObject_SetForeach(obj, field_str, field_len, cb);
+        } else if (field_type == SELVA_OBJECT_ARRAY) {
+            return array_foreach(obj, field_str, field_len, cb);
+        }
+    }
+
+    return SELVA_HIERARCHY_ENOTSUP;
+}

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -918,7 +918,6 @@ struct set_has_cb {
             const char *buf;
             size_t len;
         } str;
-        long long ll;
         double d;
     };
     int found;
@@ -954,28 +953,20 @@ static int set_has_cb(union SelvaObjectSetForeachValue value, enum SelvaSetType 
             return (data->found = 1);
         }
     } else if (type == SELVA_SET_TYPE_DOUBLE) {
-        if (data->type == SELVA_SET_TYPE_DOUBLE) {
-            if (data->d == value.d) {
-                return (data->found = 1);
-            }
-        } else if (data->type == SELVA_SET_TYPE_LONGLONG) {
-            if ((double)data->ll == value.d) {
-                return (data->found = 1);
-            }
-        } else {
+        if (data->type != SELVA_SET_TYPE_DOUBLE) {
             return 1; /* Type mismatch. */
         }
+
+        if (data->d == value.d) {
+            return (data->found = 1);
+        }
     } else if (type == SELVA_SET_TYPE_LONGLONG) {
-        if (data->type == SELVA_SET_TYPE_DOUBLE) {
-            if (data->d == (double)value.ll) {
-                return (data->found = 1);
-            }
-        } else if (data->type == SELVA_SET_TYPE_LONGLONG) {
-            if (data->ll == value.ll) {
-                return (data->found = 1);
-            }
-        } else {
+        if (data->type != SELVA_SET_TYPE_DOUBLE) {
             return 1; /* Type mismatch. */
+        }
+
+        if (data->d == (double)value.ll) {
+            return (data->found = 1);
         }
     } else if (type == SELVA_SET_TYPE_NODEID) {
         Selva_NodeId node_id;

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -971,7 +971,7 @@ static int set_has_cb(union SelvaObjectSetForeachValue value, enum SelvaSetType 
     } else if (type == SELVA_SET_TYPE_NODEID) {
         Selva_NodeId node_id;
 
-        if ((data->type != SELVA_SET_TYPE_RMSTRING && data->type != SELVA_SET_TYPE_NODEID)) {
+        if (data->type != SELVA_SET_TYPE_RMSTRING && data->type != SELVA_SET_TYPE_NODEID) {
             return 1; /* Type mismatch. */
         }
 

--- a/server/modules/selva/module/subscriptions.c
+++ b/server/modules/selva/module/subscriptions.c
@@ -111,14 +111,17 @@ static void defer_update_event(
         struct SelvaHierarchy *hierarchy,
         struct Selva_SubscriptionMarker *marker,
         unsigned short event_flags,
-        const struct SelvaHierarchyNode *node);
+        struct SelvaHierarchyNode *node);
 static void defer_trigger_event(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct Selva_SubscriptionMarker *marker,
         unsigned short event_flags,
-        const struct SelvaHierarchyNode *node);
-static void defer_event_for_traversing_markers(RedisModuleCtx *ctx, struct SelvaHierarchy *hierarchy, const struct SelvaHierarchyNode *node);
+        struct SelvaHierarchyNode *node);
+static void defer_event_for_traversing_markers(
+        RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node);
 
 /**
  * The given marker flags matches to a hierarchy marker of any kind.
@@ -203,7 +206,7 @@ static int Selva_SubscriptionFieldMatch(const struct Selva_SubscriptionMarker *m
     return match;
 }
 
-int Selva_SubscriptionFilterMatch(RedisModuleCtx *ctx, struct SelvaHierarchy *hierarchy, const struct SelvaHierarchyNode *node, struct Selva_SubscriptionMarker *marker) {
+int Selva_SubscriptionFilterMatch(RedisModuleCtx *ctx, struct SelvaHierarchy *hierarchy, struct SelvaHierarchyNode *node, struct Selva_SubscriptionMarker *marker) {
     struct rpn_ctx *filter_ctx = marker->filter_ctx;
     int res = 1; /* When no filter is set the result should be true. */
 
@@ -1383,7 +1386,7 @@ static void defer_update_event(
         struct SelvaHierarchy *hierarchy,
         struct Selva_SubscriptionMarker *marker,
         unsigned short event_flags __unused,
-        const struct SelvaHierarchyNode *node __unused) {
+        struct SelvaHierarchyNode *node __unused) {
     struct SelvaSubscriptions_DeferredEvents *def = &hierarchy->subs.deferred_events;
     struct Selva_Subscription *sub = marker->sub;
 
@@ -1397,7 +1400,7 @@ static void defer_trigger_event(
         struct SelvaHierarchy *hierarchy,
         struct Selva_SubscriptionMarker *marker,
         unsigned short event_flags __unused,
-        const struct SelvaHierarchyNode *node __unused) {
+        struct SelvaHierarchyNode *node __unused) {
     struct SelvaSubscriptions_DeferredEvents *def = &hierarchy->subs.deferred_events;
 
     if (SVector_IsInitialized(&def->triggers)) {
@@ -1451,7 +1454,7 @@ void SelvaSubscriptions_DeferMissingAccessorEvents(struct SelvaHierarchy *hierar
 static void defer_traversing(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers) {
     struct SVectorIterator it;
     struct Selva_SubscriptionMarker *marker;
@@ -1464,7 +1467,10 @@ static void defer_traversing(
     }
 }
 
-static void defer_event_for_traversing_markers(RedisModuleCtx *ctx, struct SelvaHierarchy *hierarchy, const struct SelvaHierarchyNode *node) {
+static void defer_event_for_traversing_markers(
+        RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node) {
     /* Detached markers. */
     defer_traversing(ctx, hierarchy, node, &hierarchy->subs.detached_markers);
 
@@ -1475,7 +1481,7 @@ static void defer_event_for_traversing_markers(RedisModuleCtx *ctx, struct Selva
 static void defer_hierarchy_events(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers) {
     if (isHierarchyMarker(sub_markers->flags_filter)) {
         struct SVectorIterator it;
@@ -1494,7 +1500,7 @@ static void defer_hierarchy_events(
 void SelvaSubscriptions_DeferHierarchyEvents(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node) {
+        struct SelvaHierarchyNode *node) {
     const struct SelvaHierarchyMetadata *metadata;
 
     /* Detached markers. */
@@ -1508,7 +1514,7 @@ void SelvaSubscriptions_DeferHierarchyEvents(
 static void defer_hierarchy_deletion_events(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers) {
     if (isHierarchyMarker(sub_markers->flags_filter)) {
         struct SVectorIterator it;
@@ -1530,7 +1536,7 @@ static void defer_hierarchy_deletion_events(
 void SelvaSubscriptions_DeferHierarchyDeletionEvents(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node) {
+        struct SelvaHierarchyNode *node) {
     const struct SelvaHierarchyMetadata *metadata;
 
     /* Detached markers. */
@@ -1547,17 +1553,16 @@ static void defer_alias_change_events(
         const struct Selva_SubscriptionMarkers *sub_markers,
         const Selva_NodeId node_id,
         SVector *wipe_subs) {
+    struct SelvaHierarchyNode *node;
+    struct SVectorIterator it;
+    struct Selva_SubscriptionMarker *marker;
+
     if (!isAliasMarker(sub_markers->flags_filter)) {
         /* No alias markers in this structure. */
         return;
     }
 
-    const struct SelvaHierarchyNode *node;
-
     node = SelvaHierarchy_FindNode(hierarchy, node_id);
-
-    struct SVectorIterator it;
-    struct Selva_SubscriptionMarker *marker;
 
     SVector_ForeachBegin(&it, &sub_markers->vec);
     while ((marker = SVector_Foreach(&it))) {
@@ -1582,7 +1587,7 @@ static void defer_alias_change_events(
 static void field_change_precheck(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers) {
     const unsigned short flags = SELVA_SUBSCRIPTION_FLAG_CH_FIELD;
 
@@ -1608,7 +1613,7 @@ static void field_change_precheck(
 void SelvaSubscriptions_FieldChangePrecheck(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node) {
+        struct SelvaHierarchyNode *node) {
     const struct SelvaHierarchyMetadata *metadata;
 
     /* Detached markers. */
@@ -1622,7 +1627,7 @@ void SelvaSubscriptions_FieldChangePrecheck(
 static void defer_field_change_events(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers,
         const char *field_str,
         size_t field_len) {
@@ -1655,7 +1660,7 @@ static void defer_field_change_events(
 static void defer_array_field_change_events(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         const struct Selva_SubscriptionMarkers *sub_markers,
         const char *field_str,
         size_t field_len) {
@@ -1703,7 +1708,7 @@ static void defer_array_field_change_events(
 void SelvaSubscriptions_DeferFieldChangeEvents(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         const char *field_str,
         size_t field_len) {
     if (memrchr(field_str, '[', field_len)) {
@@ -1781,7 +1786,7 @@ void SelvaSubscriptions_DeferAliasChangeEvents(
 void SelvaSubscriptions_DeferTriggerEvents(
         RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyNode *node,
+        struct SelvaHierarchyNode *node,
         enum Selva_SubscriptionTriggerType event_type) {
     /* Trigger markers are always detached and have no node_id. */
     const struct Selva_SubscriptionMarkers *sub_markers = &hierarchy->subs.detached_markers;

--- a/server/modules/selva/module/subscriptions.c
+++ b/server/modules/selva/module/subscriptions.c
@@ -206,7 +206,11 @@ static int Selva_SubscriptionFieldMatch(const struct Selva_SubscriptionMarker *m
     return match;
 }
 
-int Selva_SubscriptionFilterMatch(RedisModuleCtx *ctx, struct SelvaHierarchy *hierarchy, struct SelvaHierarchyNode *node, struct Selva_SubscriptionMarker *marker) {
+int Selva_SubscriptionFilterMatch(
+        RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        struct Selva_SubscriptionMarker *marker) {
     struct rpn_ctx *filter_ctx = marker->filter_ctx;
     int res = 1; /* When no filter is set the result should be true. */
 


### PR DESCRIPTION
Add support for "traversing" set-like fields:

- parents
- children
- ancestors
- descendants
- set data fields
- array data fields