### PR TITLE
Add Trx_Sync() to keep last visited stats for free

### DIFF
--- a/server/modules/selva/lib/util/trx.c
+++ b/server/modules/selva/lib/util/trx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 SAULX
+ * Copyright (c) 2020-2022 SAULX
  * SPDX-License-Identifier: MIT
  */
 #include <stdint.h>
@@ -18,6 +18,13 @@ int Trx_Begin(struct trx_state * restrict state, struct trx * restrict trx) {
     trx->cl = cl;
 
     return 0;
+}
+
+void Trx_Sync(const struct trx_state * restrict state, struct trx * restrict label) {
+    if (label->id != state->id) {
+        label->id = state->id;
+        label->cl = 0; /* Not visited yet. */
+    }
 }
 
 int Trx_Visit(struct trx * restrict cur_trx, struct trx * restrict label) {

--- a/server/modules/selva/lib/util/trx.h
+++ b/server/modules/selva/lib/util/trx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 SAULX
+ * Copyright (c) 2020-2022 SAULX
  * SPDX-License-Identifier: MIT
  */
 #pragma once
@@ -36,8 +36,18 @@ struct trx {
 
 /**
  * Start a new traversal.
+ * This function will either start a new transaction or select a new color
+ * for an open transaction.
  */
 int Trx_Begin(struct trx_state * restrict state, struct trx * restrict trx);
+
+/**
+ * Sync the transaction id to the label.
+ * This function is only useful if you want to update the latest transaction
+ * id to the label but you don't need to know later on if the transaction
+ * (traversal) actually visited the node.
+ */
+void Trx_Sync(const struct trx_state * restrict state, struct trx * restrict label);
 
 /**
  * Visit a node.
@@ -55,5 +65,14 @@ int Trx_HasVisited(const struct trx * restrict cur_trx, const struct trx * restr
  * End traversal.
  */
 void Trx_End(struct trx_state * restrict state, struct trx * restrict cur);
+
+/**
+ * Calculate the age of the given label.
+ * The label age is practically a distance or a difference between the current
+ * id and when the label was stamped with an id the last time.
+ */
+static inline long long Trx_LabelAge(const struct trx_state * restrict state, const struct trx * restrict label) {
+    return (long long)(state->id - label->id);
+}
 
 #endif /* _UTIL_TRX_H_ */


### PR DESCRIPTION
The database optimizations like indexing and subtree compression
would greatly benefit from being able to determine if nodes and
subtrees are visited often. We can utilize transaction ids for
that purpose, as we can determine the distance of the
current/next to the label id, which is somewhat proportional to
time.

Currently we only use transactions for tracking whether nodes
should be visited within a traversal or in a nested traversal.
The transaction colors are a scarce resource and not needed if we
just want to look a the ids. Therefore, we need to a new function
for just syncing the current transaction id to nodes when we don't
actually traverse.