### PR TITLE
Pass ctx and hierarchy on all traversals

### DIFF
--- a/server/modules/selva/include/hierarchy.h
+++ b/server/modules/selva/include/hierarchy.h
@@ -45,7 +45,7 @@ typedef void SelvaHierarchyMetadataConstructorHook(
         struct SelvaHierarchyMetadata *metadata);
 typedef void SelvaHierarchyMetadataDestructorHook(
         struct RedisModuleCtx *ctx,
-        SelvaHierarchy *hierarchy,
+        struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         struct SelvaHierarchyMetadata *metadata);
 
@@ -165,7 +165,11 @@ struct SelvaHierarchy {
  * @param node a pointer to the node.
  * @param arg a pointer to head_arg give in SelvaHierarchyCallback structure.
  */
-typedef int (*SelvaHierarchyHeadCallback)(struct SelvaHierarchyNode *node, void *arg);
+typedef int (*SelvaHierarchyHeadCallback)(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        void *arg);
 
 /**
  * Called for each node found during a traversal.
@@ -173,7 +177,11 @@ typedef int (*SelvaHierarchyHeadCallback)(struct SelvaHierarchyNode *node, void 
  * @param arg a pointer to node_arg give in SelvaHierarchyCallback structure.
  * @returns 0 to continue the traversal; 1 to interrupt the traversal.
  */
-typedef int (*SelvaHierarchyNodeCallback)(struct SelvaHierarchyNode *node, void *arg);
+typedef int (*SelvaHierarchyNodeCallback)(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        void *arg);
 
 /**
  * Traversal metadata for child/adjacent nodes.
@@ -190,6 +198,8 @@ struct SelvaHierarchyTraversalMetadata {
  * @param arg a pointer to child_arg give in SelvaHierarchyCallback structure.
  */
 typedef void (*SelvaHierarchyChildCallback)(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
         const struct SelvaHierarchyTraversalMetadata *metadata,
         struct SelvaHierarchyNode *child,
         void *arg);
@@ -452,17 +462,35 @@ static inline int SelvaHierarchy_NodeExists(SelvaHierarchy *hierarchy, const Sel
  */
 ssize_t SelvaModify_GetHierarchyHeads(SelvaHierarchy *hierarchy, Selva_NodeId **res);
 
-void SelvaHierarchy_TraverseChildren(struct SelvaHierarchyNode *node, const struct SelvaHierarchyCallback *cb);
-void SelvaHierarchy_TraverseParents(struct SelvaHierarchyNode *node, const struct SelvaHierarchyCallback *cb);
-int SelvaHierarchy_TraverseBFSAncestors(SelvaHierarchy *hierarchy, struct SelvaHierarchyNode *node, const struct SelvaHierarchyCallback *cb);
-int SelvaHierarchy_TraverseBFSDescendants(SelvaHierarchy *hierarchy, struct SelvaHierarchyNode *node, const struct SelvaHierarchyCallback *cb);
+void SelvaHierarchy_TraverseChildren(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        const struct SelvaHierarchyCallback *cb);
+void SelvaHierarchy_TraverseParents(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        const struct SelvaHierarchyCallback *cb);
+int SelvaHierarchy_TraverseBFSAncestors(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        const struct SelvaHierarchyCallback *cb);
+int SelvaHierarchy_TraverseBFSDescendants(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        const struct SelvaHierarchyCallback *cb);
 int SelvaHierarchy_Traverse(
-        SelvaHierarchy *hierarchy,
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
         enum SelvaTraversal dir,
         const struct SelvaHierarchyCallback *cb);
 int SelvaHierarchy_TraverseField(
-        SelvaHierarchy *hierarchy,
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
         enum SelvaTraversal dir,
         const char *field_name_str,
@@ -470,7 +498,7 @@ int SelvaHierarchy_TraverseField(
         const struct SelvaHierarchyCallback *cb);
 int SelvaHierarchy_TraverseExpression(
         struct RedisModuleCtx *ctx,
-        SelvaHierarchy *hierarchy,
+        struct SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
         struct rpn_ctx *rpn_ctx,
         const struct rpn_expression *rpn_expr,
@@ -479,7 +507,7 @@ int SelvaHierarchy_TraverseExpression(
         const struct SelvaHierarchyCallback *cb);
 int SelvaHierarchy_TraverseExpressionBfs(
         struct RedisModuleCtx *ctx,
-        SelvaHierarchy *hierarchy,
+        struct SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
         struct rpn_ctx *rpn_ctx,
         const struct rpn_expression *rpn_expr,
@@ -490,7 +518,8 @@ int SelvaHierarchy_TraverseExpressionBfs(
  * Foreach value in an array field.
  */
 int SelvaHierarchy_TraverseArray(
-        SelvaHierarchy *hierarchy,
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
         const char *field_str,
         size_t field_len,
@@ -499,7 +528,8 @@ int SelvaHierarchy_TraverseArray(
  * Foreach value in a set field.
  */
 int SelvaHierarchy_TraverseSet(
-        SelvaHierarchy *hierarchy,
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
         const Selva_NodeId id,
         const char *field_str,
         size_t field_len,
@@ -516,6 +546,7 @@ int SelvaHierarchy_TraverseSet(
  * - string and numeric set fields
  */
 int SelvaHierarchy_ForeachInField(
+        struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_str,

--- a/server/modules/selva/include/selva_set_ops.h
+++ b/server/modules/selva/include/selva_set_ops.h
@@ -7,6 +7,7 @@
  * data structures and Selva node fields.
  */
 
+struct RedisModuleCtx;
 struct SelvaHierarchy;
 struct SelvaHierarchyNode;
 struct SelvaSet;
@@ -21,6 +22,7 @@ struct SelvaSet;
  * Test if a set-like field has a string value.
  */
 int SelvaSet_field_has_string(
+        struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_str,
@@ -32,6 +34,7 @@ int SelvaSet_field_has_string(
  * Test if a set-like field has a double value.
  */
 int SelvaSet_field_has_double(
+        struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_str,
@@ -42,6 +45,7 @@ int SelvaSet_field_has_double(
  * Test if a set-like field has a long long value.
  */
 int SelvaSet_field_has_longlong(
+        struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_str,
@@ -67,6 +71,7 @@ int SelvaSet_seta_in_setb(struct SelvaSet *a, struct SelvaSet *b);
  * Test if the set a is a subset of the set-like field b.
  */
 int SelvaSet_seta_in_fieldb(
+        struct RedisModuleCtx *ctx,
         struct SelvaSet *a,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
@@ -77,6 +82,7 @@ int SelvaSet_seta_in_fieldb(
  * Test if the set-like field a is a subset of set b.
  */
 int SelvaSet_fielda_in_setb(
+        struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_a_str,
@@ -87,6 +93,7 @@ int SelvaSet_fielda_in_setb(
  * Test if the set-like field a is a subset of the set-like field b.
  */
 int SelvaSet_fielda_in_fieldb(
+        struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_a_str,

--- a/server/modules/selva/include/traversal.h
+++ b/server/modules/selva/include/traversal.h
@@ -115,9 +115,7 @@ struct SelvaNodeSendParam {
 };
 
 struct FindCommand_Args {
-    struct RedisModuleCtx *ctx;
     struct RedisModuleString *lang;
-    struct SelvaHierarchy *hierarchy;
 
     ssize_t *nr_nodes; /*!< Number of nodes in the result. */
     ssize_t offset; /*!< Start from nth node. */

--- a/server/modules/selva/module/hierarchy/field_set.c
+++ b/server/modules/selva/module/hierarchy/field_set.c
@@ -32,7 +32,11 @@ static int is_unsupported_field(const char *field_str, size_t field_len) {
     return 0;
 }
 
-static int hierarchy_foreach_cb(struct SelvaHierarchyNode *node, void *arg) {
+static int hierarchy_foreach_cb(
+        RedisModuleCtx *ctx __unused,
+        struct SelvaHierarchy *hierarchy __unused,
+        struct SelvaHierarchyNode *node,
+        void *arg) {
     const struct SelvaObjectSetForeachCallback *cb = (struct SelvaObjectSetForeachCallback *)arg;
     union SelvaObjectSetForeachValue svalue;
 
@@ -85,6 +89,7 @@ static int array_foreach(
 }
 
 int SelvaHierarchy_ForeachInField(
+        RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_str,
@@ -99,7 +104,7 @@ int SelvaHierarchy_ForeachInField(
             .node_arg = (void *)cb,
         };
 
-        SelvaHierarchy_TraverseParents(node, &hcb);
+        SelvaHierarchy_TraverseParents(ctx, hierarchy, node, &hcb);
         return 0;
 
     } else if (IS_FIELD(SELVA_CHILDREN_FIELD)) {
@@ -108,7 +113,7 @@ int SelvaHierarchy_ForeachInField(
             .node_arg = (void *)cb,
         };
 
-        SelvaHierarchy_TraverseChildren(node, &hcb);
+        SelvaHierarchy_TraverseChildren(ctx, hierarchy, node, &hcb);
         return 0;
     } else if (IS_FIELD(SELVA_ANCESTORS_FIELD)) {
         const struct SelvaHierarchyCallback hcb = {
@@ -116,14 +121,14 @@ int SelvaHierarchy_ForeachInField(
             .node_arg = (void *)cb,
         };
 
-        return SelvaHierarchy_TraverseBFSAncestors(hierarchy, node, &hcb);
+        return SelvaHierarchy_TraverseBFSAncestors(ctx, hierarchy, node, &hcb);
     } else if (IS_FIELD(SELVA_DESCENDANTS_FIELD)) {
         const struct SelvaHierarchyCallback hcb = {
             .node_cb = hierarchy_foreach_cb,
             .node_arg = (void *)cb,
         };
 
-        return SelvaHierarchy_TraverseBFSDescendants(hierarchy, node, &hcb);
+        return SelvaHierarchy_TraverseBFSDescendants(ctx, hierarchy, node, &hcb);
     } else if (is_unsupported_field(field_str, field_len)) {
         /* NOP */
         /* TODO Edge */

--- a/server/modules/selva/module/hierarchy/hierarchy_reply.c
+++ b/server/modules/selva/module/hierarchy/hierarchy_reply.c
@@ -14,7 +14,11 @@ struct send_hierarchy_field_data {
 /*
  * Used for ancestors, children, descendants, parents
  */
-static int send_hierarchy_field_NodeCb(struct SelvaHierarchyNode *node, void *arg) {
+static int send_hierarchy_field_NodeCb(
+        RedisModuleCtx *ctx __unused,
+        struct SelvaHierarchy *hierarchy __unused,
+        struct SelvaHierarchyNode *node,
+        void *arg) {
     Selva_NodeId nodeId;
     struct send_hierarchy_field_data *args = (struct send_hierarchy_field_data *)arg;
     int match = 0;
@@ -71,7 +75,7 @@ int HierarchyReply_WithTraversal(
      * [nodeId1, nodeId2,.. nodeIdn]
      */
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-    err = SelvaHierarchy_Traverse(hierarchy, nodeId, dir, &cb);
+    err = SelvaHierarchy_Traverse(ctx, hierarchy, nodeId, dir, &cb);
     RedisModule_ReplySetArrayLength(ctx, args.len);
 
     return err;

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -912,7 +912,7 @@ static enum rpn_error rpn_op_range(struct RedisModuleCtx *redis_ctx __unused, st
     return push_int_result(ctx, a->d <= b->d && b->d <= c->d);
 }
 
-static enum rpn_error rpn_op_has(struct RedisModuleCtx *redis_ctx __unused, struct rpn_ctx *ctx) {
+static enum rpn_error rpn_op_has(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ctx) {
     struct SelvaSet *set;
     OPERAND(ctx, s); /* set */
     OPERAND(ctx, v); /* value */
@@ -966,9 +966,9 @@ static enum rpn_error rpn_op_has(struct RedisModuleCtx *redis_ctx __unused, stru
             const char *value_str = OPERAND_GET_S(v);
             const size_t value_len = OPERAND_GET_S_LEN(v);
 
-            res = SelvaSet_field_has_string(ctx->hierarchy, ctx->node, field_name_str, field_name_len, value_str, value_len);
+            res = SelvaSet_field_has_string(redis_ctx,ctx->hierarchy, ctx->node, field_name_str, field_name_len, value_str, value_len);
         } else { /* Assume number */
-            res = SelvaSet_field_has_double(ctx->hierarchy, ctx->node, field_name_str, field_name_len, v->d);
+            res = SelvaSet_field_has_double(redis_ctx, ctx->hierarchy, ctx->node, field_name_str, field_name_len, v->d);
         }
 
         return push_int_result(ctx, !!res);
@@ -1172,7 +1172,7 @@ static enum rpn_error rpn_op_aon(struct RedisModuleCtx *redis_ctx __unused, stru
     return RPN_ERR_OK;
 }
 
-static enum rpn_error rpn_op_in(struct RedisModuleCtx *redis_ctx __unused, struct rpn_ctx *ctx) {
+static enum rpn_error rpn_op_in(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ctx) {
     struct SelvaSet *set_a;
     struct SelvaSet *set_b;
     OPERAND(ctx, a); /* set A */
@@ -1188,19 +1188,19 @@ static enum rpn_error rpn_op_in(struct RedisModuleCtx *redis_ctx __unused, struc
         const char *field_str = OPERAND_GET_S(b);
         const size_t field_len = OPERAND_GET_S_LEN(b);
 
-        res = SelvaSet_seta_in_fieldb(set_a, ctx->hierarchy, ctx->node, field_str, field_len);
+        res = SelvaSet_seta_in_fieldb(redis_ctx, set_a, ctx->hierarchy, ctx->node, field_str, field_len);
     } else if (!set_a && set_b) {
         const char *field_str = OPERAND_GET_S(a);
         const size_t field_len = OPERAND_GET_S_LEN(a);
 
-        res = SelvaSet_fielda_in_setb(ctx->hierarchy, ctx->node, field_str, field_len, set_b);
+        res = SelvaSet_fielda_in_setb(redis_ctx, ctx->hierarchy, ctx->node, field_str, field_len, set_b);
     } else if (!set_a && !set_b) {
         const char *field_a_str = OPERAND_GET_S(a);
         const size_t field_a_len = OPERAND_GET_S_LEN(a);
         const char *field_b_str = OPERAND_GET_S(b);
         const size_t field_b_len = OPERAND_GET_S_LEN(b);
 
-        res = SelvaSet_fielda_in_fieldb(ctx->hierarchy, ctx->node, field_a_str, field_a_len, field_b_str, field_b_len);
+        res = SelvaSet_fielda_in_fieldb(redis_ctx, ctx->hierarchy, ctx->node, field_a_str, field_a_len, field_b_str, field_b_len);
     }
 
     return push_int_result(ctx, res);

--- a/server/modules/selva/module/selva_set/field_has.c
+++ b/server/modules/selva/module/selva_set/field_has.c
@@ -69,6 +69,7 @@ int set_has_cb(union SelvaObjectSetForeachValue value, enum SelvaSetType type, v
 }
 
 int SelvaSet_field_has_string(
+        struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_str,
@@ -87,13 +88,14 @@ int SelvaSet_field_has_string(
     };
     int err;
 
-    err = SelvaHierarchy_ForeachInField(hierarchy, node, field_str, field_len, &cb);
+    err = SelvaHierarchy_ForeachInField(ctx, hierarchy, node, field_str, field_len, &cb);
 
     /* TODO Errors? */
     return err ? 0 : !!data.found;
 }
 
 int SelvaSet_field_has_double(
+        struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_str,
@@ -110,13 +112,14 @@ int SelvaSet_field_has_double(
     };
     int err;
 
-    err = SelvaHierarchy_ForeachInField(hierarchy, node, field_str, field_len, &cb);
+    err = SelvaHierarchy_ForeachInField(ctx, hierarchy, node, field_str, field_len, &cb);
 
     /* TODO Errors? */
     return err ? 0 : !!data.found;
 }
 
 int SelvaSet_field_has_longlong(
+        RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_str,
@@ -133,7 +136,7 @@ int SelvaSet_field_has_longlong(
     };
     int err;
 
-    err = SelvaHierarchy_ForeachInField(hierarchy, node, field_str, field_len, &cb);
+    err = SelvaHierarchy_ForeachInField(ctx, hierarchy, node, field_str, field_len, &cb);
 
     /* TODO Errors? */
     return err ? 0 : !!data.found;

--- a/server/modules/selva/module/selva_set/fielda_in_fieldb.c
+++ b/server/modules/selva/module/selva_set/fielda_in_fieldb.c
@@ -4,6 +4,7 @@
 #include "selva_set_ops.h"
 
 struct sosfv_in_field {
+    RedisModuleCtx *ctx;
     struct SelvaHierarchy *hierarchy;
     struct SelvaHierarchyNode *node;
     const char *field_b_str; /*!< Name of the set-like field. */
@@ -21,17 +22,17 @@ static int sosfv_in_field(union SelvaObjectSetForeachValue value, enum SelvaSetT
             size_t value_len;
             const char *value_str = RedisModule_StringPtrLen(value.rms, &value_len);
 
-            has = SelvaSet_field_has_string(data->hierarchy, data->node, data->field_b_str, data->field_b_len, value_str, value_len);
+            has = SelvaSet_field_has_string(data->ctx, data->hierarchy, data->node, data->field_b_str, data->field_b_len, value_str, value_len);
         }
         break;
     case SELVA_SET_TYPE_DOUBLE:
-        has = SelvaSet_field_has_double(data->hierarchy, data->node, data->field_b_str, data->field_b_len, value.d);
+        has = SelvaSet_field_has_double(data->ctx, data->hierarchy, data->node, data->field_b_str, data->field_b_len, value.d);
         break;
     case SELVA_SET_TYPE_LONGLONG:
-        has = SelvaSet_field_has_longlong(data->hierarchy, data->node, data->field_b_str, data->field_b_len, value.ll);
+        has = SelvaSet_field_has_longlong(data->ctx, data->hierarchy, data->node, data->field_b_str, data->field_b_len, value.ll);
         break;
     case SELVA_SET_TYPE_NODEID:
-        has = SelvaSet_field_has_string(data->hierarchy, data->node, data->field_b_str, data->field_b_len, value.node_id, SELVA_NODE_ID_SIZE);
+        has = SelvaSet_field_has_string(data->ctx, data->hierarchy, data->node, data->field_b_str, data->field_b_len, value.node_id, SELVA_NODE_ID_SIZE);
         break;
     case SELVA_SET_NR_TYPES:
         /* Invalid type? */
@@ -42,6 +43,7 @@ static int sosfv_in_field(union SelvaObjectSetForeachValue value, enum SelvaSetT
 }
 
 int SelvaSet_fielda_in_fieldb(
+        RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_a_str,
@@ -49,6 +51,7 @@ int SelvaSet_fielda_in_fieldb(
         const char *field_b_str,
         size_t field_b_len) {
     struct sosfv_in_field data = {
+        .ctx = ctx,
         .hierarchy = hierarchy,
         .node = node,
         .field_b_str = field_b_str,
@@ -61,7 +64,7 @@ int SelvaSet_fielda_in_fieldb(
     };
     int err;
 
-    err = SelvaHierarchy_ForeachInField(hierarchy, node, field_a_str, field_a_len, &cb);
+    err = SelvaHierarchy_ForeachInField(ctx, hierarchy, node, field_a_str, field_a_len, &cb);
     /* TODO Handle errors? */
 
     return err ? 0 : data.valid;

--- a/server/modules/selva/module/selva_set/fielda_in_setb.c
+++ b/server/modules/selva/module/selva_set/fielda_in_setb.c
@@ -38,6 +38,7 @@ static int sosfv_in_set(union SelvaObjectSetForeachValue value, enum SelvaSetTyp
 }
 
 int SelvaSet_fielda_in_setb(
+        RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
         const char *field_a_str,
@@ -53,7 +54,7 @@ int SelvaSet_fielda_in_setb(
     };
     int err;
 
-    err = SelvaHierarchy_ForeachInField(hierarchy, node, field_a_str, field_a_len, &cb);
+    err = SelvaHierarchy_ForeachInField(ctx, hierarchy, node, field_a_str, field_a_len, &cb);
     /* TODO Handle errors? */
 
     return err ? 0 : data.valid;

--- a/server/modules/selva/module/selva_set/seta_in_fieldb.c
+++ b/server/modules/selva/module/selva_set/seta_in_fieldb.c
@@ -70,6 +70,7 @@ static int sosfv_in_set(union SelvaObjectSetForeachValue value, enum SelvaSetTyp
 }
 
 int SelvaSet_seta_in_fieldb(
+        RedisModuleCtx *ctx,
         struct SelvaSet *a,
         struct SelvaHierarchy *hierarchy,
         struct SelvaHierarchyNode *node,
@@ -85,7 +86,7 @@ int SelvaSet_seta_in_fieldb(
     };
     int err;
 
-    err = SelvaHierarchy_ForeachInField(hierarchy, node, field_b_str, field_b_len, &cb);
+    err = SelvaHierarchy_ForeachInField(ctx, hierarchy, node, field_b_str, field_b_len, &cb);
     /* TODO Handle errors? */
 
     return err ? 0 : data.found == SelvaSet_Size(a);


### PR DESCRIPTION
`ctx` and `hierarchy` are almost always needed by the caller of
traversals, so it would be much simpler to just always pass them.
Passing `ctx` will also later on allow using it within hierarchy
traversal functions for compression and indexing related tasks.