### PR TITLE
Simple ordered indices

### DIFF
--- a/client/test/findIndexHint.ts
+++ b/client/test/findIndexHint.ts
@@ -238,6 +238,6 @@ test.serial('traversal expression with index', async (t) => {
 
   t.deepEqual(
     (await client.redis.selva_index_list('___selva_hierarchy')).map((v, i) => i % 2 === 0 ? v : v[3]),
-    [ `${id}.O.eyJwYXJlbnRzIiwiY2hpbGRyZW4ifQ==.IzQgInZhbHVlIiBnIEU=`, '674' ]
+    [ `${id}.O.eyJwYXJlbnRzIiwiY2hpbGRyZW4ifQ==.B.dmFsdWU=.IzQgInZhbHVlIiBnIEU=`, '674' ]
   )
 })

--- a/client/test/findWithOrderedIndex.ts
+++ b/client/test/findWithOrderedIndex.ts
@@ -1,0 +1,133 @@
+import test from 'ava'
+import { connect } from '../src/index'
+import { start } from '@saulx/selva-server'
+import './assertions'
+import { wait } from './assertions'
+import getPort from 'get-port'
+
+let srv
+let port
+
+test.before(async (t) => {
+  port = await getPort()
+  srv = await start({
+    port,
+    selvaOptions: ['FIND_INDEXING_THRESHOLD', '5', 'FIND_INDICES_MAX', '2', 'FIND_INDEXING_INTERVAL', '10', 'FIND_INDEXING_ICB_UPDATE_INTERVAL', '1', 'FIND_INDEXING_POPULARITY_AVE_PERIOD', '1'],
+  })
+
+  await wait(500)
+})
+
+test.beforeEach(async (t) => {
+  const client = connect({ port: port }, { loglevel: 'info' })
+
+  await client.redis.flushall()
+  await client.updateSchema({
+    languages: ['en'],
+    types: {
+      league: {
+        prefix: 'le',
+        fields: {
+          name: { type: 'string' },
+          thing: { type: 'string' },
+          things: { type: 'set', items: { type: 'string' } },
+          cat: { type: 'int' },
+        },
+      },
+      match: {
+        prefix: 'ma',
+        fields: {
+          name: { type: 'string' },
+          description: { type: 'text' },
+          value: {
+            type: 'number',
+          },
+          status: { type: 'number' },
+        },
+      },
+    },
+  })
+
+  // A small delay is needed after setting the schema
+  await new Promise((r) => setTimeout(r, 100))
+
+  await client.destroy()
+})
+
+test.afterEach(async (t) => {
+  const client = connect({ port: port })
+  await new Promise((r) => setTimeout(r, 100))
+  await client.delete('root')
+  await client.destroy()
+})
+
+test.after(async (t) => {
+  const client = connect({ port: port })
+  await client.destroy()
+  await srv.destroy()
+  await t.connectionsAreEmpty()
+})
+
+const chars = '123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+test.serial('find index', async (t) => {
+  // simple nested - single query
+  const client = connect({ port: port }, { loglevel: 'info' })
+
+  await client.set({
+    type: 'league',
+    name: 'league 0',
+  })
+  for (let i = 0; i < chars.length; i++) {
+    await client.set({
+      type: 'league',
+      name: `league ${i + 1}`,
+      thing: `${chars.charAt(i)}`,
+    })
+  }
+
+  const q = {
+    $id: 'root',
+    id: true,
+    items: {
+      name: true,
+      $list: {
+        $sort: { $field: 'thing', $order: 'asc' },
+        $find: {
+          $traverse: 'descendants',
+          $filter: [
+            {
+              $field: 'type',
+              $operator: '=',
+              $value: 'league',
+            },
+            {
+              $field: 'thing',
+              $operator: 'exists',
+            },
+          ],
+        },
+      },
+    },
+  }
+
+  for (let i = 0; i < 300; i++) {
+    t.deepEqual(
+      await client.get(q),
+      {
+        id: 'root',
+        items: Array(chars.length).fill(null).map((_, i) => ({ name: `league ${i + 1}` }))
+      }
+    )
+    await wait(1)
+  }
+
+  t.deepEqual((await client.redis.selva_index_list('___selva_hierarchy')).map((v, i) => i % 2 === 0 ? v : v[3]), [
+    'root.J.B.dGhpbmc=.ImxlIiBl',
+    '36',
+    'root.J.B.dGhpbmc=.InRoaW5nIiBo',
+    '35',
+  ])
+
+  await client.destroy()
+})

--- a/client/test/indexStability.ts
+++ b/client/test/indexStability.ts
@@ -225,22 +225,26 @@ test.serial('index stability', async (t) => {
       const stateMap = {}
 
       for (let i = 0; i < l.length; i += 2) {
-        const name = Buffer.from(l[i].split('.')[2], 'base64').toString()
-        const state = l[i + 1][3]
+        const key = l[i].split('.');
+        const expression = Buffer.from(key[key.length - 1], 'base64').toString()
+        const state = {
+          expression: expression,
+          take_max_ave: l[i + 1][0],
+          tot_max_ave: l[i + 1][1],
+          ind_take_max_ave: l[i + 1][2],
+          card: l[i + 1][3],
+        }
 
-        stateMap[name] = state;
+        stateMap[l[i]] = state;
       }
 
         if (i >= 120) {
-            //console.log(stateMap)
-            t.deepEqualIgnoreOrder(stateMap, {
-              '"ma" e': '399',
-              '"children" {"ma1"} l': 'not_active',
-              '"le" e': 'not_active',
-              '"te" e': '51',
-              '"value" g #1 F': 'not_active',
-              '"value" g #2 F': 'not_active'
-            })
+            t.deepEqual(stateMap['root.J.InRlIiBl']?.card, '51') // q1, q3
+            t.deepEqual(stateMap['root.J.InZhbHVlIiBnICMyIEY=']?.card, '6') // q1
+            t.deepEqual(stateMap['root.J.B.dmFsdWU=.Im1hIiBl']?.card, 'not_active') // q2
+            t.deepEqual(stateMap['root.J.B.dmFsdWU=.InZhbHVlIiBnICMxIEY=']?.card, 'not_active') // q3
+            t.deepEqual(stateMap['root.J.ImxlIiBl']?.card, 'not_active') // q4, q5
+            t.deepEqual(stateMap['root.J.ImNoaWxkcmVuIiB7Im1hMSJ9IGw=']?.card, 'not_active') // q5
         }
     }
   })

--- a/client/test/perf/indexingOrder.ts
+++ b/client/test/perf/indexingOrder.ts
@@ -1,0 +1,130 @@
+import test from 'ava'
+import { performance } from 'perf_hooks'
+import { connect } from '../../src/index'
+import { start } from '@saulx/selva-server'
+import '../assertions'
+import { wait } from '../assertions'
+import getPort from 'get-port'
+
+let srv
+let port
+
+test.before(async (t) => {
+  port = await getPort()
+  srv = await start({
+    port,
+    selvaOptions: ['FIND_INDEXING_THRESHOLD', '100', 'FIND_INDICES_MAX', '2', 'FIND_INDEXING_INTERVAL', '2000', 'FIND_INDEXING_ICB_UPDATE_INTERVAL', '100', 'FIND_INDEXING_POPULARITY_AVE_PERIOD', '1'],
+  })
+
+  await wait(500)
+})
+
+test.beforeEach(async (t) => {
+  const client = connect({ port: port }, { loglevel: 'info' })
+
+  await client.redis.flushall()
+  await client.updateSchema({
+    languages: ['en'],
+    types: {
+      league: {
+        prefix: 'le',
+        fields: {
+          name: { type: 'string' },
+          thing: { type: 'string' },
+          things: { type: 'set', items: { type: 'string' } },
+          cat: { type: 'int' },
+        },
+      },
+      match: {
+        prefix: 'ma',
+        fields: {
+          name: { type: 'string' },
+          description: { type: 'text' },
+          value: {
+            type: 'number',
+          },
+          status: { type: 'number' },
+        },
+      },
+    },
+  })
+
+  // A small delay is needed after setting the schema
+  await new Promise((r) => setTimeout(r, 100))
+
+  await client.destroy()
+})
+
+test.afterEach(async (t) => {
+  const client = connect({ port: port })
+  await new Promise((r) => setTimeout(r, 100))
+  await client.delete('root')
+  await client.destroy()
+})
+
+test.after(async (t) => {
+  const client = connect({ port: port })
+  await client.destroy()
+  await srv.destroy()
+  await t.connectionsAreEmpty()
+})
+
+const N = 50000
+
+test.serial('find index order', async (t) => {
+  const client = connect({ port: port }, { loglevel: 'info' })
+
+  await client.set({
+    type: 'league',
+    name: 'league 0',
+  })
+  for (let i = 0; i < N; i++) {
+    await client.set({
+      type: 'league',
+      name: `league ${i + 1}`,
+      thing: `${(Math.random() + 1).toString(36).substring(7)}`,
+    })
+  }
+
+  const q = {
+    $id: 'root',
+    id: true,
+    items: {
+      name: true,
+      $list: {
+        $sort: { $field: 'thing', $order: 'asc' },
+        $find: {
+          $traverse: 'descendants',
+          $filter: [
+            {
+              $field: 'type',
+              $operator: '=',
+              $value: 'league',
+            },
+            {
+              $field: 'thing',
+              $operator: 'exists',
+            },
+          ],
+        },
+      },
+    },
+  }
+
+  for (let i = 0; i < 300; i++) {
+    await client.get(q)
+  }
+  await wait(1e3)
+
+  const indexStart = performance.now()
+  for (let i = 0; i < 1000; i++) {
+    await client.get(q)
+  }
+  const indexTime = performance.now() - indexStart
+  console.log(indexTime)
+
+  console.log(await client.redis.selva_index_list('___selva_hierarchy'))
+  t.pass()
+
+  await client.destroy()
+})

--- a/server/modules/selva/include/find_index.h
+++ b/server/modules/selva/include/find_index.h
@@ -7,6 +7,7 @@
 #define _FIND_INDEX_H_
 
 #include "traversal.h"
+#include "traversal_order.h"
 
 struct RedisModuleCtx;
 struct RedisModuleString;
@@ -29,6 +30,8 @@ size_t SelvaFind_IcbCard(const struct SelvaFindIndexControlBlock *icb);
 
 /**
  * Check if an index exists for this query, update it, and get the indexing result set.
+ * @param order Set to other than SELVA_RESULT_ORDER_NONE if the index should be sorted.
+ * @param order_field Should be non-NULL only if the index should be sorted.
  * @param out is a SelvaSet of node_ids indexed for given clause.
  */
 int SelvaFind_AutoIndex(
@@ -36,8 +39,19 @@ int SelvaFind_AutoIndex(
         struct SelvaHierarchy *hierarchy,
         enum SelvaTraversal dir, struct RedisModuleString *dir_expression_str,
         const Selva_NodeId node_id,
+        enum SelvaResultOrder order,
+        struct RedisModuleString *order_field,
         struct RedisModuleString *filter,
         struct SelvaFindIndexControlBlock **icb_out);
+
+/**
+ * Check whether an ICB is created as an ordered.
+ * This function doesn't check whether the index is actually valid.
+ */
+int SelvaFind_IsOrderedIndex(
+        struct SelvaFindIndexControlBlock *icb,
+        enum SelvaResultOrder order,
+        struct RedisModuleString *order_field);
 
 int SelvaFind_TraverseIndex(
         struct RedisModuleCtx *ctx,

--- a/server/modules/selva/include/find_index.h
+++ b/server/modules/selva/include/find_index.h
@@ -43,8 +43,8 @@ int SelvaFind_TraverseIndex(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaFindIndexControlBlock *icb,
-        SelvaHierarchyNodeCallback node_cb, /* TODO Move these types to traversal.h */
-        void * node_arg);
+        SelvaHierarchyNodeCallback node_cb,
+        void *node_arg);
 
 /**
  * Update indexing accounting.

--- a/server/modules/selva/include/find_index.h
+++ b/server/modules/selva/include/find_index.h
@@ -25,6 +25,8 @@ int SelvaFindIndex_Init(struct RedisModuleCtx *ctx, struct SelvaHierarchy *hiera
  */
 void SelvaFindIndex_Deinit(struct SelvaHierarchy *hierarchy);
 
+size_t SelvaFind_IcbCard(const struct SelvaFindIndexControlBlock *icb);
+
 /**
  * Check if an index exists for this query, update it, and get the indexing result set.
  * @param out is a SelvaSet of node_ids indexed for given clause.
@@ -35,14 +37,23 @@ int SelvaFind_AutoIndex(
         enum SelvaTraversal dir, struct RedisModuleString *dir_expression_str,
         const Selva_NodeId node_id,
         struct RedisModuleString *filter,
-        struct SelvaFindIndexControlBlock **icb_out,
-        struct SelvaSet **out);
+        struct SelvaFindIndexControlBlock **icb_out);
+
+int SelvaFind_TraverseIndex(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaFindIndexControlBlock *icb,
+        SelvaHierarchyNodeCallback node_cb, /* TODO Move these types to traversal.h */
+        void * node_arg);
 
 /**
  * Update indexing accounting.
  * @param acc_take is the number of nodes taken from the original set.
  * @param acc_tot is the total number of nodes in the original set.
  */
-void SelvaFind_Acc(struct SelvaFindIndexControlBlock * restrict icb, size_t acc_take, size_t acc_tot);
+void SelvaFind_Acc(
+        struct SelvaFindIndexControlBlock * restrict icb,
+        size_t acc_take,
+        size_t acc_tot);
 
 #endif /* _FIND_INDEX_H_ */

--- a/server/modules/selva/include/hierarchy.h
+++ b/server/modules/selva/include/hierarchy.h
@@ -183,51 +183,6 @@ struct SelvaHierarchy {
 };
 
 /**
- * Called for the first node in the traversal.
- * This is typically the node that was given as an argument to a traversal function.
- * @param node a pointer to the node.
- * @param arg a pointer to head_arg give in SelvaHierarchyCallback structure.
- */
-typedef int (*SelvaHierarchyHeadCallback)(
-        struct RedisModuleCtx *ctx,
-        struct SelvaHierarchy *hierarchy,
-        struct SelvaHierarchyNode *node,
-        void *arg);
-
-/**
- * Called for each node found during a traversal.
- * @param node a pointer to the node.
- * @param arg a pointer to node_arg give in SelvaHierarchyCallback structure.
- * @returns 0 to continue the traversal; 1 to interrupt the traversal.
- */
-typedef int (*SelvaHierarchyNodeCallback)(
-        struct RedisModuleCtx *ctx,
-        struct SelvaHierarchy *hierarchy,
-        struct SelvaHierarchyNode *node,
-        void *arg);
-
-/**
- * Traversal metadata for child/adjacent nodes.
- */
-struct SelvaHierarchyTraversalMetadata {
-    const char *origin_field_str;
-    size_t origin_field_len;
-    struct SelvaHierarchyNode *origin_node;
-};
-
-/**
- * Called for each adjacent node during a traversal.
- * @param node a pointer to the node.
- * @param arg a pointer to child_arg give in SelvaHierarchyCallback structure.
- */
-typedef void (*SelvaHierarchyChildCallback)(
-        struct RedisModuleCtx *ctx,
-        struct SelvaHierarchy *hierarchy,
-        const struct SelvaHierarchyTraversalMetadata *metadata,
-        struct SelvaHierarchyNode *child,
-        void *arg);
-
-/**
  * Callback descriptor used for traversals.
  */
 struct SelvaHierarchyCallback {

--- a/server/modules/selva/include/traversal.h
+++ b/server/modules/selva/include/traversal.h
@@ -114,6 +114,51 @@ struct FindCommand_Args {
     size_t acc_tot; /*!< Total number of nodes visited during the traversal. */
 };
 
+/**
+ * Called for the first node in the traversal.
+ * This is typically the node that was given as an argument to a traversal function.
+ * @param node a pointer to the node.
+ * @param arg a pointer to head_arg give in SelvaHierarchyCallback structure.
+ */
+typedef int (*SelvaHierarchyHeadCallback)(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        void *arg);
+
+/**
+ * Called for each node found during a traversal.
+ * @param node a pointer to the node.
+ * @param arg a pointer to node_arg give in SelvaHierarchyCallback structure.
+ * @returns 0 to continue the traversal; 1 to interrupt the traversal.
+ */
+typedef int (*SelvaHierarchyNodeCallback)(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        struct SelvaHierarchyNode *node,
+        void *arg);
+
+/**
+ * Traversal metadata for child/adjacent nodes.
+ */
+struct SelvaHierarchyTraversalMetadata {
+    const char *origin_field_str;
+    size_t origin_field_len;
+    struct SelvaHierarchyNode *origin_node;
+};
+
+/**
+ * Called for each adjacent node during a traversal.
+ * @param node a pointer to the node.
+ * @param arg a pointer to child_arg give in SelvaHierarchyCallback structure.
+ */
+typedef void (*SelvaHierarchyChildCallback)(
+        struct RedisModuleCtx *ctx,
+        struct SelvaHierarchy *hierarchy,
+        const struct SelvaHierarchyTraversalMetadata *metadata,
+        struct SelvaHierarchyNode *child,
+        void *arg);
+
 int SelvaTraversal_ParseDir2(enum SelvaTraversal *dir, const struct RedisModuleString *arg);
 int SelvaTraversal_FieldsContains(struct SelvaObject *fields, const char *field_name_str, size_t field_name_len);
 int SelvaTraversal_GetSkip(enum SelvaTraversal dir);

--- a/server/modules/selva/include/traversal_order.h
+++ b/server/modules/selva/include/traversal_order.h
@@ -30,13 +30,21 @@ enum SelvaResultOrder {
 };
 
 int SelvaTraversal_ParseOrder(
-        const struct RedisModuleString **order_by_field,
+        struct RedisModuleString **order_by_field,
         enum SelvaResultOrder *order,
         const struct RedisModuleString *txt,
-        const struct RedisModuleString *fld,
-        const struct RedisModuleString *ord);
+        struct RedisModuleString *fld,
+        struct RedisModuleString *ord);
 
 int SelvaTraversalOrder_InitOrderResult(SVector *order_result, enum SelvaResultOrder order, ssize_t limit);
+
+/**
+ * Destroy an order_result SVector and free its items properly.
+ * If SelvaTraversalOrder_CreateOrderItem() was called with a ctx then ctx this
+ * function should be called with a ctx too. Alternatively the order_result
+ * SVector can be declared with SVECTOR_AUTOFREE().
+ */
+void SelvaTraversalOrder_DestroyOrderResult(RedisModuleCtx *ctx, SVector *order_result);
 
 /**
  * Create a new TraversalOrderItem that can be sorted.
@@ -47,6 +55,7 @@ struct TraversalOrderItem *SelvaTraversalOrder_CreateOrderItem(
         struct RedisModuleString *lang,
         struct SelvaHierarchyNode *node,
         const struct RedisModuleString *order_field);
+void SelvaTraversalOrder_DestroyOrderItem(RedisModuleCtx *ctx, struct TraversalOrderItem *item);
 struct TraversalOrderItem *SelvaTraversalOrder_CreateObjectBasedOrderItem(
         struct RedisModuleCtx *ctx,
         struct RedisModuleString *lang,

--- a/server/modules/selva/module/aggregate.c
+++ b/server/modules/selva/module/aggregate.c
@@ -594,7 +594,7 @@ int SelvaHierarchy_AggregateCommand(RedisModuleCtx *ctx, RedisModuleString **arg
      * Parse the order arg.
      */
     enum SelvaResultOrder order = SELVA_RESULT_ORDER_NONE;
-    const RedisModuleString *order_by_field = NULL;
+    RedisModuleString *order_by_field = NULL;
     if (argc > ARGV_ORDER_ORD) {
         err = SelvaTraversal_ParseOrder(&order_by_field, &order,
                           argv[ARGV_ORDER_TXT],
@@ -893,7 +893,7 @@ int SelvaHierarchy_AggregateInCommand(RedisModuleCtx *ctx, RedisModuleString **a
      * Parse the order arg.
      */
     enum SelvaResultOrder order = SELVA_RESULT_ORDER_NONE;
-    const RedisModuleString *order_by_field = NULL;
+    RedisModuleString *order_by_field = NULL;
     if (argc > ARGV_ORDER_ORD) {
         err = SelvaTraversal_ParseOrder(&order_by_field, &order,
                           argv[ARGV_ORDER_TXT],

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -1637,11 +1637,10 @@ static int SelvaHierarchy_FindCommand(RedisModuleCtx *ctx, RedisModuleString **a
     /*
      * An index result set together with limit may yield different order than
      * the node order in the hierarchy, so we skip the indexing when a limit
-     * is given. However, if an order is given together with the limit, then
-     * we can use indexing because the final result is sorted and limited after
-     * the node filtering.
+     * is given.
+     * TODO Support $limit with ordered indices.
      */
-    if (nr_index_hints > 0 && limit != -1 && order == SELVA_RESULT_ORDER_NONE) {
+    if (nr_index_hints > 0 && limit != -1) {
         nr_index_hints = 0;
     }
 

--- a/server/modules/selva/module/find_index/find_index.c
+++ b/server/modules/selva/module/find_index/find_index.c
@@ -1203,6 +1203,11 @@ int SelvaFind_TraverseIndex(
         struct SelvaFindIndexControlBlock *icb,
         SelvaHierarchyNodeCallback node_cb,
         void * node_arg) {
+    /*
+     * Note that we don't break here on limit because limit and indexing are
+     * incompatible. The reason is that we can't guarantee that the returned
+     * nodes would be the exactly same with and without indexing.
+     */
     if (icb->flags.ordered) {
         struct SVectorIterator it;
         const struct TraversalOrderItem *item;
@@ -1213,7 +1218,6 @@ int SelvaFind_TraverseIndex(
 
             node = SelvaHierarchy_FindNode(hierarchy, item->node_id);
             if (node) {
-                /* TODO In this case find.c wouldn't need to sort again. */
                 (void)node_cb(ctx, hierarchy, node, node_arg);
             }
         }
@@ -1225,13 +1229,6 @@ int SelvaFind_TraverseIndex(
 
             node = SelvaHierarchy_FindNode(hierarchy, el->value_nodeId);
             if (node) {
-                /*
-                 * Note that we don't break here on limit because limit and
-                 * indexing are incompatible, unless limit is used together
-                 * with order.
-                 * The reason is that we can't guarantee that the returned nodes
-                 * would be the exactly same with and without indexing.
-                 */
                 (void)node_cb(ctx, hierarchy, node, node_arg);
             }
         }

--- a/server/modules/selva/module/find_index/find_index.c
+++ b/server/modules/selva/module/find_index/find_index.c
@@ -194,7 +194,7 @@ static void create_indexing_timer(RedisModuleCtx *ctx, struct SelvaHierarchy *hi
 /**
  * Calculate the length of an index name.
  */
-static size_t calc_name_len(const Selva_NodeId node_id, struct upsert_icb *desc) {
+static size_t calc_name_len(const Selva_NodeId node_id, const struct upsert_icb *desc) {
     size_t filter_len;
     size_t n;
 
@@ -230,7 +230,7 @@ static size_t calc_name_len(const Selva_NodeId node_id, struct upsert_icb *desc)
  * node_id.<direction>[.<dir expression>][.<sort order>.<order field>].H(<indexing clause>)
  * @param buf is a buffer that has at least the length given by calc_name_len().
  */
-static void build_name(char *buf, const Selva_NodeId node_id, struct upsert_icb *desc) {
+static void build_name(char *buf, const Selva_NodeId node_id, const struct upsert_icb *desc) {
     size_t filter_len;
     const char *filter_str = RedisModule_StringPtrLen(desc->filter, &filter_len);
     char *s = buf;
@@ -269,6 +269,9 @@ static void build_name(char *buf, const Selva_NodeId node_id, struct upsert_icb 
     s += base64_encode_s(s, filter_str, filter_len, 0);
 }
 
+/**
+ * Get an ICB from the index map.
+ */
 static int get_icb(struct SelvaHierarchy *hierarchy, const char *name_str, size_t name_len, struct SelvaFindIndexControlBlock **icb) {
     struct SelvaObject *dyn_index = hierarchy->dyn_index.index_map;
     void *p;
@@ -280,13 +283,19 @@ static int get_icb(struct SelvaHierarchy *hierarchy, const char *name_str, size_
     return err;
 }
 
+/**
+ * Add an ICB to the index map.
+ */
 static int set_icb(struct SelvaHierarchy *hierarchy, const char *name_str, size_t name_len, struct SelvaFindIndexControlBlock *icb) {
     struct SelvaObject *dyn_index = hierarchy->dyn_index.index_map;
 
     return SelvaObject_SetPointerStr(dyn_index, name_str, name_len, icb, NULL);
 }
 
-static int del_icb(struct SelvaHierarchy *hierarchy, struct SelvaFindIndexControlBlock *icb) {
+/**
+ * Remove an ICB from the index map.
+ */
+static int del_icb(struct SelvaHierarchy *hierarchy, const struct SelvaFindIndexControlBlock *icb) {
     return SelvaObject_DelKeyStr(hierarchy->dyn_index.index_map, icb->name_str, icb->name_len);
 }
 
@@ -1196,7 +1205,7 @@ int SelvaFind_TraverseIndex(
         void * node_arg) {
     if (icb->flags.ordered) {
         struct SVectorIterator it;
-        struct TraversalOrderItem *item;
+        const struct TraversalOrderItem *item;
 
         SVector_ForeachBegin(&it, &icb->res.ord);
         while ((item = SVector_Foreach(&it))) {


### PR DESCRIPTION
New features:
- Traverse indices in find_index.c instead of find.c
- Create an ordered ICB when the find query has an order argument
- Allow ordered queries to use either ordered or unordered index

What's not implemented:
- Ordered query could technically accept any order and re-sort the result
- Unordered query could accept any order