### PR TITLE
Retrieve nested references in find

### DIFF
--- a/client/test/edgeFieldNested.ts
+++ b/client/test/edgeFieldNested.ts
@@ -1,0 +1,185 @@
+import test from 'ava'
+import { connect } from '../src/index'
+import { start } from '@saulx/selva-server'
+import './assertions'
+import { wait } from './assertions'
+import getPort from 'get-port'
+
+let srv
+let port: number
+
+test.before(async (t) => {
+  port = await getPort()
+  srv = await start({
+    port,
+  })
+  const client = connect({ port }, { loglevel: 'info' })
+
+  await client.updateSchema({
+    languages: ['en'],
+    types: {
+      league: {
+        prefix: 'le',
+        fields: {},
+      },
+      team: {
+        prefix: 'te',
+        fields: {
+          value: { type: 'number' },
+        },
+      },
+      match: {
+        prefix: 'ma',
+        fields: {
+          value: { type: 'number' },
+          status: { type: 'number' },
+        },
+      },
+      thing: {
+        prefix: 'th',
+        fields: {
+          docs: { type: 'references' },
+        },
+      },
+      file: {
+        prefix: 'tx',
+        fields: {
+          name: { type: 'string' },
+          mirrors: { type: 'references' },
+        },
+      },
+      mirror: {
+        prefix: 'sp',
+        fields: {
+          url: { type: 'string' },
+        },
+      },
+    },
+  })
+
+  await client.destroy()
+})
+
+test.after(async (t) => {
+  const client = connect({ port })
+  await client.delete('root')
+  await client.destroy()
+  await srv.destroy()
+  await t.connectionsAreEmpty()
+})
+
+test.serial.only('retrieving nested refs with fields arg', async (t) => {
+  const client = connect({ port })
+
+  for (let i = 0; i < 2; i++) {
+    await client.set({
+      type: 'thing',
+      docs: [...Array(2)].map((_, i) => ({
+        type: 'file',
+        $id: `tx${i}`,
+        name: `file${i}.txt`,
+        mirrors: [
+          {
+            type: 'mirror',
+            url: `http://localhost:3000/file${i}.txt`,
+          },
+          {
+            type: 'mirror',
+            url: `http://localhost:3001/file${i}.txt`,
+          },
+        ]
+      }))
+    })
+  }
+
+  const res1 = await client.redis.selva_hierarchy_find('', '___selva_hierarchy', 'descendants', 'limit', '1', 'fields', 'docs.*', 'root', '"th" e')
+  t.deepEqualIgnoreOrder(res1[0][1], [
+    "docs",
+    [
+      [
+        "id",
+        "tx0",
+        "name",
+        "file0.txt",
+        "type",
+        "file"
+      ],
+      [
+        "id",
+        "tx1",
+        "name",
+        "file1.txt",
+        "type",
+        "file"
+      ]
+    ]
+  ])
+
+  const res2 = await client.redis.selva_hierarchy_find('', '___selva_hierarchy', 'descendants', 'limit', '1', 'fields', 'docs.name\ndocs.mirrors.url', 'root', '"th" e')
+  t.deepEqual(res2[0][1][0], 'docs')
+  t.deepEqual(res2[0][1][1], [
+   [
+     "name",
+     "file0.txt"
+   ],
+   [
+     "name",
+     "file1.txt"
+   ]
+ ])
+ t.deepEqual(res2[0][1][2], 'docs')
+ t.truthy(res2[0][1][3][0].length === 2)
+ t.deepEqual(res2[0][1][3][0][0], 'mirrors')
+ t.deepEqual(res2[0][1][3][0][1][0][0], 'url')
+ t.deepEqual(res2[0][1][3][1][0], 'mirrors')
+
+  const res3 = await client.redis.selva_hierarchy_find('', '___selva_hierarchy', 'descendants', 'limit', '1', 'fields', 'docs.name\ndocs.mirrors.url\n!docs.mirrors.url', 'root', '"th" e')
+  t.deepEqualIgnoreOrder(res3[0][1], [
+    "docs",
+    [
+      [
+        "name",
+        "file0.txt"
+      ],
+      [
+        "name",
+        "file1.txt"
+      ]
+    ]
+  ])
+
+  const res4 = await client.redis.selva_hierarchy_find('', '___selva_hierarchy', 'descendants', 'limit', '1', 'fields', 'id\ndocs.id\ndocs.name\ndocs.mirrors.*\n!id', 'root', '"th" e')
+  t.deepEqual(res4[0][1][0], 'id', 'id not excluded')
+
+  // Excluding fields over a multi-edge field doesn't currently work
+  const res5= await client.redis.selva_hierarchy_find('', '___selva_hierarchy', 'descendants', 'fields', 'docs.id\ndocs.name\ndocs.mirrors.*\n!docs.mirrors.id', 'root', '"th" e')
+  t.deepEqual(res5[0][1][0], 'docs')
+  t.deepEqual(res5[0][1][1][0][0], 'id') // hence we have id here anyway
+  t.deepEqual(res5[0][1][1][1][0], 'id')
+  t.deepEqual(res5[0][1][2], 'docs')
+  t.deepEqual(res5[0][1][3][0][0], 'name')
+  t.deepEqual(res5[0][1][3][0][1], 'file0.txt')
+  t.deepEqual(res5[0][1][3][1][0], 'name')
+  t.deepEqual(res5[0][1][3][1][1], 'file1.txt')
+  t.deepEqual(res5[0][1][4], 'docs')
+  t.deepEqual(res5[0][1][5][0][0], 'mirrors')
+  t.truthy(res5[0][1][5][0][1].length === 2)
+  t.truthy(res5[0][1][5][0][1][0].length === 6)
+  t.truthy(res5[0][1][5][0][1][1].length === 6)
+  t.deepEqual(res5[1][1][0], 'docs')
+  t.deepEqual(res5[1][1][1][0][0], 'id')
+  t.deepEqual(res5[1][1][1][1][0], 'id')
+  t.deepEqual(res5[1][1][2], 'docs')
+  t.deepEqual(res5[1][1][3][0][0], 'name')
+  t.deepEqual(res5[1][1][3][0][1], 'file0.txt')
+  t.deepEqual(res5[1][1][3][1][0], 'name')
+  t.deepEqual(res5[1][1][3][1][1], 'file1.txt')
+  t.deepEqual(res5[1][1][4], 'docs')
+  t.deepEqual(res5[1][1][5][0][0], 'mirrors')
+  t.truthy(res5[1][1][5][0][1].length === 2)
+  t.truthy(res5[1][1][5][0][1][0].length === 6)
+  t.truthy(res5[1][1][5][0][1][1].length === 6)
+
+  await client.delete('root')
+  await client.destroy()
+})

--- a/server/modules/selva/include/edge.h
+++ b/server/modules/selva/include/edge.h
@@ -199,6 +199,14 @@ int Edge_HasNodeId(const struct EdgeField *edge_field, const Selva_NodeId dst_no
  */
 int Edge_DerefSingleRef(const struct EdgeField *edge_field, struct SelvaHierarchyNode **node_out);
 
+static inline void Edge_ForeachBegin(struct SVectorIterator *it, const struct EdgeField *edge_field) {
+    SVector_ForeachBegin(it, &edge_field->arcs);
+}
+
+static inline struct SelvaHierarchyNode *Edge_Foreach(struct SVectorIterator *it) {
+    return SVector_Foreach(it);
+}
+
 /**
  * Add a new edge.
  * If the field doesn't exist it will be created using the given constraint_id.

--- a/server/modules/selva/module/arg_parser.c
+++ b/server/modules/selva/module/arg_parser.c
@@ -190,12 +190,17 @@ int SelvaArgsParser_StringSetList(
                     if (excl && cur_el[0] == excl_prefix) {
                         if (el_len > 1) {
                             const char sep[] = { set_separator };
+                            const char *name_str = cur_el + 1;
+                            const size_t name_len = el_len - 1;
 
-                            if (RedisModule_StringAppendBuffer(ctx, excl, cur_el + 1, el_len - 1) ||
-                                RedisModule_StringAppendBuffer(ctx, excl, sep, 1)) {
-                                goto fail;
+                            /* Ignore id field silently. */
+                            if (!(name_len == (sizeof(SELVA_ID_FIELD) - 1) && !memcmp(SELVA_ID_FIELD, name_str, name_len))) {
+                                if (RedisModule_StringAppendBuffer(ctx, excl, name_str, name_len) ||
+                                    RedisModule_StringAppendBuffer(ctx, excl, sep, 1)) {
+                                    goto fail;
+                                }
+                                nr_excl++;
                             }
-                            nr_excl++;
                         }
                         /* Otherwise we ignore the empty element. */
                     } else {

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -144,54 +144,105 @@ static int send_edge_field(
      * Note: The dst_node might be the same as node but this shouldn't case
      * an infinite loop or any other issues as we'll be always cutting the
      * field name shorter and thus the recursion should eventually stop.
+     * TODO Not very nice to access arcs directly.
      */
+    const size_t nr_arcs = SVector_Size(&edge_field->arcs);
+    struct SVectorIterator it;
     struct SelvaHierarchyNode *dst_node;
-    int err = Edge_DerefSingleRef(edge_field, &dst_node);
-    if (err) {
-        return err;
+
+    /*
+     * RFE Historically we have been sending ENOENT but is that a good practice?
+     */
+    if (nr_arcs == 0) {
+        return SELVA_ENOENT;
     }
 
-    const char *next_field_str = field_str + off;
-    size_t next_field_len = field_len - off;
+    /* TODO Not very nice to dig into the edge internals here. */
+    const int single_ref = edge_field->constraint && edge_field->constraint->flags & EDGE_FIELD_CONSTRAINT_FLAG_SINGLE_REF;
 
-    const char *next_prefix_str;
-    size_t next_prefix_len;
-
-    if (field_prefix_str) {
-        const char *s = strnstrn(field_str, field_len, ".", 1);
-        const int n = s ? (int)(s - field_str) + 1 : (int)field_len;
-        const RedisModuleString *next_prefix;
-
-        next_prefix = RedisModule_CreateStringPrintf(ctx, "%.*s%.*s", (int)field_prefix_len, field_prefix_str, n, field_str);
-        next_prefix_str = RedisModule_StringPtrLen(next_prefix, &next_prefix_len);
-    } else {
-        next_prefix_str = field_str;
-        next_prefix_len = off;
+    if (!single_ref) {
+        /* We need to send results in an array if it's a references field. */
+        RedisModule_ReplyWithStringBuffer(ctx, field_str, off - 1);
+        RedisModule_ReplyWithArray(ctx, nr_arcs);
     }
 
-    if (next_field_len == 1 && next_field_str[0] == '*') {
-        int res;
+    Edge_ForeachBegin(&it, edge_field);
+    while ((dst_node = Edge_Foreach(&it))) {
+        const char *next_field_str = field_str + off;
+        size_t next_field_len = field_len - off;
+        const int is_wildcard = next_field_len == 1 && next_field_str[0] == WILDCARD_CHAR;
 
-        RedisModule_ReplyWithStringBuffer(ctx, next_prefix_str, next_prefix_len - 1);
-        RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+        const char *next_prefix_str;
+        size_t next_prefix_len;
 
-        res = send_all_node_data_fields(ctx, lang, hierarchy, dst_node, NULL, 0, excluded_fields);
-        if (res < 0) {
-            res = 0;
+        if (field_prefix_str) {
+            const char *s = strnstrn(field_str, field_len, ".", 1);
+            const int n = s ? (int)(s - field_str) + 1 : (int)field_len;
+            const RedisModuleString *next_prefix;
+
+            /* RFE Handle error? */
+            next_prefix = RedisModule_CreateStringPrintf(ctx, "%.*s%.*s", (int)field_prefix_len, field_prefix_str, n, field_str);
+            next_prefix_str = RedisModule_StringPtrLen(next_prefix, &next_prefix_len);
+        } else if (!single_ref) {
+            /*
+             * Don't add prefix because we are sending multiple nested objects
+             * in an array.
+             */
+            next_prefix_str = NULL;
+            next_prefix_len = 0;
+        } else {
+            next_prefix_str = field_str;
+            next_prefix_len = off;
         }
 
-        RedisModule_ReplySetArrayLength(ctx, 2 * res);
-        return 0;
-    } else {
-        struct SelvaObject *dst_obj = SelvaHierarchy_GetNodeObject(dst_node);
-        int res;
+        if (is_wildcard) {
+            int res;
 
-        res = send_node_field(ctx, lang, hierarchy, dst_node, dst_obj, next_prefix_str, next_prefix_len, next_field_str, next_field_len, excluded_fields);
+            if (next_prefix_str) {
+                if (!single_ref) {
+                    /* See comment below. */
+                    RedisModule_ReplyWithArray(ctx, 2);
+                }
+                RedisModule_ReplyWithStringBuffer(ctx, next_prefix_str, next_prefix_len - 1);
+            }
 
-        return res == 0 ? SELVA_ENOENT : 0;
+            RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+            /*
+             * RFE Excluding fields doesn't currently work with wildcard.
+             */
+            res = send_all_node_data_fields(ctx, lang, hierarchy, dst_node,
+                    is_wildcard ? NULL : next_prefix_str, is_wildcard ? 0 : next_prefix_len,
+                    NULL);
+            if (res < 0) {
+                res = 0;
+            }
+
+            RedisModule_ReplySetArrayLength(ctx, 2 * res);
+        } else {
+            struct SelvaObject *dst_obj = SelvaHierarchy_GetNodeObject(dst_node);
+            int res;
+
+            if (!single_ref) {
+                /*
+                 * Sending an array of objects as this is a references field,
+                 * so we need a new array here.
+                 */
+                RedisModule_ReplyWithArray(ctx, 2);
+            }
+
+            res = send_node_field(ctx, lang, hierarchy, dst_node, dst_obj, next_prefix_str, next_prefix_len, next_field_str, next_field_len, excluded_fields);
+            if (res == 0 && single_ref) {
+                return SELVA_ENOENT;
+            }
+        }
     }
+
+    return 0;
 }
 
+/**
+ * @param excluded_fields can be set if certain field names should be excluded from the response; Otherwise NULL.
+ */
 static int send_node_field(
         RedisModuleCtx *ctx,
         RedisModuleString *lang,
@@ -225,6 +276,10 @@ static int send_node_field(
     }
 
     if (excluded_fields) {
+        /* Excluding node_id is not allowed but we can drop it from the list in the arg_parser. */
+#if 0
+        && !(full_field_name_len == (sizeof(SELVA_ID_FIELD) - 1) && !memcmp(SELVA_ID_FIELD, full_field_name_str, full_field_name_len))
+#endif
         TO_STR(excluded_fields);
 
         if (stringlist_searchn(excluded_fields_str, full_field_name_str, full_field_name_len)) {
@@ -312,6 +367,9 @@ static int send_node_field(
     return 1;
 }
 
+/**
+ * @param excluded_fields can be set if certain field names should be excluded from the response; Otherwise NULL.
+ */
 static int send_all_node_data_fields(
         RedisModuleCtx *ctx,
         RedisModuleString *lang,

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -116,7 +116,7 @@ static int send_edge_field(
     struct EdgeField *edge_field;
     void *p;
 
-    int off = SelvaObject_GetPointerPartialMatchStr(edges, field_str, field_len, &p);
+    const int off = SelvaObject_GetPointerPartialMatchStr(edges, field_str, field_len, &p);
     edge_field = p;
     if (off < 0) {
         return off;


### PR DESCRIPTION
Previously we allowed retrieving fields from a single-ref field
but it's often useful to allow retrieving all fields from an edge
field point to multiple nodes, e.g. dereferencing a `references`
field. The client must be careful to not retrieve a too big field
as `limit` does not apply when dereferencing edge fields.