### PR TITLE
Isolate ICB management from rest of the indexing

### DIFF
--- a/server/modules/selva/Makefile
+++ b/server/modules/selva/Makefile
@@ -19,6 +19,8 @@ OBJS := \
 	module/errors.o \
 	module/find.o \
 	module/find_index/find_index.o \
+	module/find_index/icb.o \
+	module/find_index/pick_icb.o \
 	module/hierarchy/field_set.o \
 	module/hierarchy/hierarchy.o \
 	module/hierarchy/hierarchy_detached.o \

--- a/server/modules/selva/include/find_index.h
+++ b/server/modules/selva/include/find_index.h
@@ -26,7 +26,7 @@ int SelvaFindIndex_Init(struct RedisModuleCtx *ctx, struct SelvaHierarchy *hiera
  */
 void SelvaFindIndex_Deinit(struct SelvaHierarchy *hierarchy);
 
-size_t SelvaFind_IcbCard(const struct SelvaFindIndexControlBlock *icb);
+size_t SelvaFindIndex_IcbCard(const struct SelvaFindIndexControlBlock *icb);
 
 /**
  * Check if an index exists for this query, update it, and get the indexing result set.
@@ -34,7 +34,7 @@ size_t SelvaFind_IcbCard(const struct SelvaFindIndexControlBlock *icb);
  * @param order_field Should be non-NULL only if the index should be sorted.
  * @param out is a SelvaSet of node_ids indexed for given clause.
  */
-int SelvaFind_AutoIndex(
+int SelvaFindIndex_Auto(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         enum SelvaTraversal dir, struct RedisModuleString *dir_expression_str,
@@ -48,12 +48,12 @@ int SelvaFind_AutoIndex(
  * Check whether an ICB is created as an ordered.
  * This function doesn't check whether the index is actually valid.
  */
-int SelvaFind_IsOrderedIndex(
+int SelvaFindIndex_IsOrdered(
         struct SelvaFindIndexControlBlock *icb,
         enum SelvaResultOrder order,
         struct RedisModuleString *order_field);
 
-int SelvaFind_TraverseIndex(
+int SelvaFindIndex_Traverse(
         struct RedisModuleCtx *ctx,
         struct SelvaHierarchy *hierarchy,
         struct SelvaFindIndexControlBlock *icb,
@@ -65,7 +65,7 @@ int SelvaFind_TraverseIndex(
  * @param acc_take is the number of nodes taken from the original set.
  * @param acc_tot is the total number of nodes in the original set.
  */
-void SelvaFind_Acc(
+void SelvaFindIndex_Acc(
         struct SelvaFindIndexControlBlock * restrict icb,
         size_t acc_take,
         size_t acc_tot);

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -1747,10 +1747,10 @@ static int SelvaHierarchy_FindCommand(RedisModuleCtx *ctx, RedisModuleString **a
                  * Hint: It's possible to disable ordered indices completely
                  * by changing order here to SELVA_RESULT_ORDER_NONE.
                  */
-                ind_err = SelvaFind_AutoIndex(ctx, hierarchy, dir, dir_expr, nodeId, order, order_by_field, index_hints[j], &icb);
+                ind_err = SelvaFindIndex_Auto(ctx, hierarchy, dir, dir_expr, nodeId, order, order_by_field, index_hints[j], &icb);
                 ind_icb[j] = icb;
                 if (!ind_err) {
-                    if (icb && (ind_select < 0 || SelvaFind_IcbCard(icb) < SelvaFind_IcbCard(ind_icb[ind_select]))) {
+                    if (icb && (ind_select < 0 || SelvaFindIndex_IcbCard(icb) < SelvaFindIndex_IcbCard(ind_icb[ind_select]))) {
                         ind_select = j; /* Select the smallest index res set for fastest lookup. */
                     }
                 } else if (ind_err != SELVA_ENOENT) {
@@ -1769,7 +1769,7 @@ static int SelvaHierarchy_FindCommand(RedisModuleCtx *ctx, RedisModuleString **a
          */
         if (ind_select >= 0 &&
             ids_len == SELVA_NODE_ID_SIZE &&
-            SelvaFind_IsOrderedIndex(ind_icb[ind_select], order, order_by_field)) {
+            SelvaFindIndex_IsOrdered(ind_icb[ind_select], order, order_by_field)) {
             order = SELVA_RESULT_ORDER_NONE;
             order_by_field = NULL; /* This controls sorting in the callback. */
         }
@@ -1814,7 +1814,7 @@ static int SelvaHierarchy_FindCommand(RedisModuleCtx *ctx, RedisModuleString **a
             }
 
             SELVA_TRACE_BEGIN(cmd_find_index);
-            err = SelvaFind_TraverseIndex(ctx, hierarchy, ind_icb[ind_select], FindCommand_NodeCb, &args);
+            err = SelvaFindIndex_Traverse(ctx, hierarchy, ind_icb[ind_select], FindCommand_NodeCb, &args);
             SELVA_TRACE_END(cmd_find_index);
         } else if (dir == SELVA_HIERARCHY_TRAVERSAL_ARRAY && ref_field) {
             struct FindCommand_ArrayObjectCb array_args = {
@@ -1894,13 +1894,13 @@ static int SelvaHierarchy_FindCommand(RedisModuleCtx *ctx, RedisModuleString **a
             }
 
             if (j == ind_select) {
-                SelvaFind_Acc(icb, args.acc_take, args.acc_tot);
+                SelvaFindIndex_Acc(icb, args.acc_take, args.acc_tot);
             } else if (ind_select == -1) {
                 /* No index was selected so all will get the same take. */
-                SelvaFind_Acc(icb, args.acc_take, args.acc_tot);
+                SelvaFindIndex_Acc(icb, args.acc_take, args.acc_tot);
             } else {
                 /* Nothing taken from this index. */
-                SelvaFind_Acc(icb, 0, args.acc_tot);
+                SelvaFindIndex_Acc(icb, 0, args.acc_tot);
             }
         }
     }

--- a/server/modules/selva/module/find_index/icb.c
+++ b/server/modules/selva/module/find_index/icb.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021-2022 SAULX
+ * SPDX-License-Identifier: (MIT WITH selva-exception) OR AGPL-3.0-only
+ */
+#include <stddef.h>
+#include "base64.h"
+#include "redismodule.h"
+#include "svector.h"
+#include "selva.h"
+#include "selva_set.h"
+#include "traversal.h"
+#include "traversal_order.h"
+#include "hierarchy.h"
+#include "icb.h"
+
+size_t SelvaFindIndexICB_CalcNameLen(const Selva_NodeId node_id, const struct icb_descriptor *desc) {
+    size_t filter_len;
+    size_t n;
+
+    (void)RedisModule_StringPtrLen(desc->filter, &filter_len);
+
+    n = Selva_NodeIdLen(node_id) + base64_out_len(filter_len, 0) + 3;
+
+    if (desc->dir == SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION) {
+        size_t dir_expression_len;
+
+        (void)RedisModule_StringPtrLen(desc->dir_expression, &dir_expression_len);
+
+        /*
+         * Currently only expressions are supported in addition to fixed
+         * field name traversals.
+         */
+        n += base64_out_len(dir_expression_len, 0) + 1;
+    }
+
+    if (desc->sort.order != SELVA_RESULT_ORDER_NONE) {
+        size_t order_field_len;
+
+        (void)RedisModule_StringPtrLen(desc->sort.order_field, &order_field_len);
+
+        n += base64_out_len(order_field_len, 0) + 3;
+    }
+
+    return n;
+}
+
+void SelvaFindIndexICB_BuildName(char *buf, const Selva_NodeId node_id, const struct icb_descriptor *desc) {
+    size_t filter_len;
+    const char *filter_str = RedisModule_StringPtrLen(desc->filter, &filter_len);
+    char *s = buf;
+
+    /* node_id */
+    memcpy(s, node_id, Selva_NodeIdLen(node_id));
+    s += Selva_NodeIdLen(node_id);
+
+    /* direction */
+    *s++ = '.';
+    *s++ = 'A' + (char)__builtin_ffs(desc->dir);
+    *s++ = '.';
+
+    if (desc->dir == SELVA_HIERARCHY_TRAVERSAL_BFS_EXPRESSION) {
+        size_t dir_expression_len;
+        const char *dir_expression_str = RedisModule_StringPtrLen(desc->dir_expression, &dir_expression_len);
+
+        if (dir_expression_len > 0) {
+            s += base64_encode_s(s, dir_expression_str, dir_expression_len, 0);
+            *s++ = '.';
+        }
+    }
+
+    /* order */
+    if (desc->sort.order != SELVA_RESULT_ORDER_NONE) {
+        size_t order_field_len;
+        const char *order_field_str = RedisModule_StringPtrLen(desc->sort.order_field, &order_field_len);
+
+        *s++ = 'A' + (char)desc->sort.order;
+        *s++ = '.';
+        s += base64_encode_s(s, order_field_str, order_field_len, 0); /* This must be always longer than 0 */
+        *s++ = '.';
+    }
+
+    /* indexing clause filter */
+    s += base64_encode_s(s, filter_str, filter_len, 0);
+}
+
+int SelvaFindIndexICB_Get(struct SelvaHierarchy *hierarchy, const char *name_str, size_t name_len, struct SelvaFindIndexControlBlock **icb) {
+    struct SelvaObject *dyn_index = hierarchy->dyn_index.index_map;
+    void *p;
+    int err;
+
+    err = SelvaObject_GetPointerStr(dyn_index, name_str, name_len, &p);
+    *icb = p;
+
+    /* TODO This requires testing. Should we do it also here or only here? */
+#if 0
+    /*
+     * Increment popularity counter.
+     * We do it here too so that the counter is updated even if we end up
+     * falling back to another index.
+     */
+    if (icb && icb->pop_count.cur < INT_MAX) {
+        icb->pop_count.cur++;
+    }
+#endif
+
+    return err;
+}
+
+int SelvaFindIndexICB_Set(struct SelvaHierarchy *hierarchy, const char *name_str, size_t name_len, struct SelvaFindIndexControlBlock *icb) {
+    struct SelvaObject *dyn_index = hierarchy->dyn_index.index_map;
+
+    return SelvaObject_SetPointerStr(dyn_index, name_str, name_len, icb, NULL);
+}
+
+int SelvaFindIndexICB_Del(struct SelvaHierarchy *hierarchy, const struct SelvaFindIndexControlBlock *icb) {
+    return SelvaObject_DelKeyStr(hierarchy->dyn_index.index_map, icb->name_str, icb->name_len);
+}

--- a/server/modules/selva/module/find_index/icb.h
+++ b/server/modules/selva/module/find_index/icb.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2021-2022 SAULX
+ * SPDX-License-Identifier: (MIT WITH selva-exception) OR AGPL-3.0-only
+ */
+#pragma once
+#ifndef _FIND_INDEX_ICB_
+#define _FIND_INDEX_ICB_
+
+/*
+ * Manage ICB map: name -> ICB.
+ */
+
+/**
+ * Sorting descriptor for ordered index.
+ */
+struct index_order {
+    enum SelvaResultOrder order; /*!< Index order if applicable. */
+    RedisModuleString *order_field; /*!< Index order by field. */
+};
+
+/**
+ * Index descriptor struct for upsert_icb().
+ */
+struct icb_descriptor {
+    enum SelvaTraversal dir; /*!< Indexing traversal direction. */
+    RedisModuleString *dir_expression; /*!< Indexing traversal expression. (optional) */
+    RedisModuleString *filter; /*!< Indexing filter. */
+    struct index_order sort;
+};
+
+/**
+ * Indexing hint accounting and indices.
+ */
+struct SelvaFindIndexControlBlock {
+    struct {
+        /**
+         * Permanently created by the user.
+         * Permanent ICBs are never destroyed and they are prioritized for
+         * indexing.
+         */
+        unsigned permanent : 1;
+        /**
+         * Marker id is selected.
+         * `marker_id` in this struct is valid only if this flag is set.
+         */
+        unsigned valid_marked_id : 1;
+        /**
+         * A timer has been registered and timer_id is valid.
+         */
+        unsigned valid_timer_id : 1;
+        /**
+         * Indexing is active.
+         * The index `res` set is actively being updated although `res` can be
+         * invalid from time to time, meaning that the index is currently
+         * invalid.
+         */
+        unsigned active : 1;
+        /**
+         * The indexing result `res` is considered valid.
+         * This can go 0 even when we are indexing if the `res.set` SelvaSet
+         * needs to be refreshed after a `SELVA_SUBSCRIPTION_FLAG_CL_HIERARCHY`
+         * event was received.
+         */
+        unsigned valid : 1;
+        /**
+         * The index is ordered.
+         * Use `res.ord` instead of `res.set`.
+         */
+        unsigned ordered: 1;
+    } flags;
+
+    /**
+     * Subscription marker updating the index.
+     */
+    Selva_SubscriptionMarkerId marker_id;
+
+    /**
+     * Timer refreshing this index control block.
+     */
+    RedisModuleTimerID timer_id;
+
+    /**
+     * Find result set size accounting.
+     */
+    struct {
+        /**
+         * The full search domain size.
+         * This is the nubmer of nodes we must traverse to build the find result
+         * without indexing.
+         */
+        float tot_max;
+        float tot_max_ave; /*!< Average of `tot_max` over time. */
+
+        /**
+         * The number of nodes selected for the find result.
+         * This number is updated when the index is not valid and we traversed
+         * the hierarchy.
+         */
+        float take_max;
+        float take_max_ave; /*!< Average of `take_max` over time. */
+
+        /**
+         * The number of nodes taken from the `res` SelvaSet when the index is valid.
+         * This is updated when the index is valid during a find.
+         */
+        float ind_take_max;
+        float ind_take_max_ave; /*!< Average of `ind_take` over time. */
+    } find_acc;
+
+    /**
+     * Hint popularity counter.
+     */
+    struct {
+        int cur; /*!< Times the hint has been seen during the current period. */
+        float ave; /*!< Average times seen over a period of time (FIND_INDEXING_POPULARITY_AVE_PERIOD). */
+    } pop_count;
+
+    /**
+     * The ICB timer (icb_proc()) needs a reference back to the hierarchy.
+     */
+    struct SelvaHierarchy *hierarchy;
+
+    /*
+     * Traversal.
+     */
+    struct {
+        Selva_NodeId node_id; /*!< Starting node_id. */
+        enum SelvaTraversal dir; /*!< Traversal direction for the index. */
+        RedisModuleString *dir_expression; /*!< Traversal direction rpn expression. */
+        RedisModuleString *filter; /*!< Indexing rpn filter. */
+    } traversal;
+
+    struct index_order sort;
+
+    /**
+     * Result set of the indexing clause.
+     * Only valid if `flags.valid` is set.
+     * The elements in this set are Selva_NodeIds.
+     */
+    union {
+        /**
+         * Unordered indexing result.
+         */
+        struct SelvaSet set;
+        /**
+         * Ordered indexing result.
+         */
+        struct SVector ord;
+    } res;
+
+    /**
+     * Length of name_str.
+     */
+    size_t name_len;
+
+    /**
+     * The name of this ICB in the index for reverse lookup.
+     */
+    char name_str[0];
+};
+
+/**
+ * Calculate the length of an index name.
+ */
+size_t SelvaFindIndexICB_CalcNameLen(const Selva_NodeId node_id, const struct icb_descriptor *desc);
+
+/**
+ * Create a deterministic name for an index.
+ * node_id.<direction>[.<dir expression>][.<sort order>.<order field>].H(<indexing clause>)
+ * @param buf is a buffer that has at least the length given by SelvaFindIndexICB_CalcNameLen().
+ */
+void SelvaFindIndexICB_BuildName(char *buf, const Selva_NodeId node_id, const struct icb_descriptor *desc);
+
+/**
+ * Get an ICB from the index map.
+ */
+int SelvaFindIndexICB_Get(struct SelvaHierarchy *hierarchy, const char *name_str, size_t name_len, struct SelvaFindIndexControlBlock **icb);
+
+/**
+ * Add an ICB to the index map.
+ */
+int SelvaFindIndexICB_Set(struct SelvaHierarchy *hierarchy, const char *name_str, size_t name_len, struct SelvaFindIndexControlBlock *icb);
+
+/**
+ * Remove an ICB from the index map.
+ */
+int SelvaFindIndexICB_Del(struct SelvaHierarchy *hierarchy, const struct SelvaFindIndexControlBlock *icb);
+
+#endif /* _FIND_INDEX_ICB_ */

--- a/server/modules/selva/module/find_index/pick_icb.c
+++ b/server/modules/selva/module/find_index/pick_icb.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 SAULX
+ * SPDX-License-Identifier: (MIT WITH selva-exception) OR AGPL-3.0-only
+ */
+#include <stddef.h>
+#include "redismodule.h"
+#include "svector.h"
+#include "selva.h"
+#include "traversal.h"
+#include "traversal_order.h"
+#include "hierarchy.h"
+#include "icb.h"
+
+/**
+ * Pick a valid unordered ICB.
+ */
+static struct SelvaFindIndexControlBlock *pick_unordered(struct SelvaHierarchy *hierarchy, const Selva_NodeId node_id, const struct icb_descriptor *desc) {
+    struct icb_descriptor icb_desc;
+    struct SelvaFindIndexControlBlock *icb_unord = NULL;
+    int err;
+
+    memcpy(&icb_desc, desc, sizeof(icb_desc));
+    icb_desc.sort.order = SELVA_RESULT_ORDER_NONE;
+    icb_desc.sort.order_field = NULL;
+
+    const size_t name_len = SelvaFindIndexICB_CalcNameLen(node_id, &icb_desc);
+    char name_str[name_len];
+
+    SelvaFindIndexICB_BuildName(name_str, node_id, &icb_desc);
+    err = SelvaFindIndexICB_Get(hierarchy, name_str, name_len, &icb_unord);
+
+    return err ? NULL : icb_unord;
+}
+
+struct SelvaFindIndexControlBlock *SelvaFindIndexICB_Pick(
+        struct SelvaHierarchy *hierarchy,
+        const Selva_NodeId node_id,
+        const struct icb_descriptor *desc,
+        struct SelvaFindIndexControlBlock *first) {
+    struct SelvaFindIndexControlBlock *icb = first;
+
+    if (icb && icb->flags.valid) {
+        /* First prefer requested index if it's valid. */
+        return icb;
+    }
+
+    const enum SelvaResultOrder order = desc->sort.order;
+    if (order != SELVA_RESULT_ORDER_NONE) {
+        /* Fallback to unordered index. */
+        struct SelvaFindIndexControlBlock *icb_unord;
+
+        icb_unord = pick_unordered(hierarchy, node_id, desc);
+        if (!icb || (icb_unord && icb_unord->flags.valid)) {
+            icb = icb_unord;
+        }
+
+        /*
+         * TODO As find allows us to return any order in addition to the requested,
+         * we should try to check if we have anything matching the query in case
+         * icb_unord was not valid.
+         */
+    } else if (order == SELVA_RESULT_ORDER_NONE) {
+        /*
+         * TODO
+         * Unordered find query (doesn't support $limit with indexing) can accept
+         * any order. Try to find any valid index with the right dir and clause.
+         */
+    }
+
+    return icb;
+}

--- a/server/modules/selva/module/find_index/pick_icb.h
+++ b/server/modules/selva/module/find_index/pick_icb.h
@@ -6,6 +6,15 @@
 #ifndef _FIND_INDEX_PICK_ICB_
 #define _FIND_INDEX_PICK_ICB_
 
+/**
+ * Pick an ICB.
+ * 1. If first is valid then the function simply returns it;
+ * 2. Otherwise, the function attempts for find a close match that's a super
+ *    set of `desc` but doesn't necessarily have the same ordering as requested.
+ * @parama first is a pointer to the exact match (ICB) to `desc` but not
+ *               necessarily a valid index..
+ * @returns a pointer to a potentially valid ICB.
+ */
 struct SelvaFindIndexControlBlock *SelvaFindIndexICB_Pick(
         struct SelvaHierarchy *hierarchy,
         const Selva_NodeId node_id,

--- a/server/modules/selva/module/find_index/pick_icb.h
+++ b/server/modules/selva/module/find_index/pick_icb.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 SAULX
+ * SPDX-License-Identifier: (MIT WITH selva-exception) OR AGPL-3.0-only
+ */
+#pragma once
+#ifndef _FIND_INDEX_PICK_ICB_
+#define _FIND_INDEX_PICK_ICB_
+
+struct SelvaFindIndexControlBlock *SelvaFindIndexICB_Pick(
+        struct SelvaHierarchy *hierarchy,
+        const Selva_NodeId node_id,
+        const struct icb_descriptor *desc,
+        struct SelvaFindIndexControlBlock *first);
+
+#endif /* _FIND_INDEX_PICK_ICB_ */


### PR DESCRIPTION
Move ICB map management into a new translation unit.

Create a new unit that picks the best match for the requested
index. Note that `find.c` will still call the indexing subsystem
multiple times to get several ICBs to choose from. Picking will
only change which ICBs will end up into that set of ICBs to select
from.