### PR TITLE
Fix retrieving fields over references with $find

### DIFF
--- a/client/src/get/executeGetOperations/find.ts
+++ b/client/src/get/executeGetOperations/find.ts
@@ -860,6 +860,7 @@ const executeFindOperation = async (
         continue
       }
 
+      const isNestedObject = (v: any) => Array.isArray(v[0])
       const parseNestedFieldReference = (path: string, v: any[]) => {
         const nestedId = v[1]
         for (let i = 2; i < v.length; i += 2) {
@@ -869,9 +870,9 @@ const executeFindOperation = async (
           const fullPath = `${isReferences ? path.slice(0, -2) : path}.${nestedField}`
 
           const nestedFieldSchema = getNestedSchema(schema, nestedId, nestedField)
-          if (nestedFieldSchema.type === 'reference') {
+          if (nestedFieldSchema?.type === 'reference' && isNestedObject(nestedValue)) {
             parseNestedFieldReference(fullPath, nestedValue[0])
-          } else if (nestedFieldSchema.type === 'references') {
+          } else if (nestedFieldSchema?.type === 'references' && isNestedObject(nestedValue)) {
               for (let i = 0; i < value.length; i++) {
                 parseNestedFieldReference(`${fullPath}[]`, nestedValue[i])
               }
@@ -897,9 +898,9 @@ const executeFindOperation = async (
       }
 
       const sourceFieldSchema = getNestedSchema(schema, id, field)
-      if (sourceFieldSchema.type === 'reference') {
+      if (sourceFieldSchema?.type === 'reference' && isNestedObject(value)) {
         parseNestedFieldReference(field, value[0])
-      } else if (sourceFieldSchema.type === 'references') {
+      } else if (sourceFieldSchema?.type === 'references' && isNestedObject(value)) {
         for (let i = 0; i < value.length; i++) {
           parseNestedFieldReference(`${field}[]`, value[i])
         }

--- a/client/src/get/utils.ts
+++ b/client/src/get/utils.ts
@@ -148,7 +148,14 @@ export const setNestedResult = (
     for (let i = 0; i < len - 1; i++) {
       segment = segment[fields[i]] || (segment[fields[i]] = {})
     }
-    segment[fields[len - 1]] = value
+    if (Array.isArray(value)) {
+      if (!Array.isArray(segment[fields[len - 1]])) {
+        segment[fields[len - 1]] = [];
+      }
+      segment[fields[len - 1]].push(...value)
+    } else {
+      segment[fields[len - 1]] = value
+    }
   } else {
     result[field] = value
   }

--- a/client/test/edgeField.ts
+++ b/client/test/edgeField.ts
@@ -793,7 +793,32 @@ test.serial('deref node references on find', async(t) => {
 
   t.deepEqual(
     await client.redis.selva_hierarchy_find('', '___selva_hierarchy', 'node', 'fields', 'title\nhomeTeam.name\nhomeTeam.club.name\nhomeTeam.club.manager.name', 'match1'),
-    [[ 'match1', [ 'title', 'Best Game', 'homeTeam.name', 'Funny Team', 'homeTeam.club.name', 'Funny Club', 'homeTeam.club.manager.name', 'dung' ]]]
+    [[
+      'match1', [
+        'title', 'Best Game',
+        'homeTeam', [[
+          'id', 'team1',
+          'name', 'Funny Team',
+        ]],
+        'homeTeam', [[
+          'id', 'team1',
+          'club', [[
+            'id', 'club1',
+            'name', 'Funny Club',
+          ]],
+        ]],
+        'homeTeam', [[
+          'id', 'team1',
+          'club', [[
+            'id', 'club1',
+            'manager', [[
+             'id', 'manager1',
+             'name', 'dung'
+            ]],
+          ]],
+        ]],
+      ],
+    ]]
   )
 })
 
@@ -1103,7 +1128,7 @@ test.serial('wildcard find with edge fields', async (t) => {
 
   t.deepEqual(
     await client.redis.selva_hierarchy_find('', '___selva_hierarchy', 'node', 'fields', 'thing.ding', 'root'),
-    [[ 'root', [ 'thing.ding', 'dong' ]]]
+    [[ 'root', [ 'thing', [[ 'id', 'ma1', 'ding', 'dong' ]]]]]
   )
   t.deepEqual(
     await client.redis.selva_hierarchy_find('', '___selva_hierarchy', 'node', 'fields', 'thing.*', 'root'),
@@ -1112,14 +1137,16 @@ test.serial('wildcard find with edge fields', async (t) => {
         "root",
         [
           "thing",
-          [
+          [[
+            "id",
+            "ma1",
             "ding",
             "dong",
             "dong",
             "ding",
             "id",
-            "ma1"
-          ]
+            "ma1",
+          ]]
         ]
       ]
     ]
@@ -1131,14 +1158,18 @@ test.serial('wildcard find with edge fields', async (t) => {
       'things',
       [
         [
-          'ding',
-          'dong',
-          'dong',
-          'ding',
           'id',
           'ma1',
+          'ding',
+          'dong',
+          'dong',
+          'ding',
+          "id",
+          "ma1",
         ],
         [
+          'id',
+          'ma2',
           'ding',
           'dong',
           'dong',
@@ -1203,10 +1234,14 @@ test.serial('wildcard find with edge fields and data fields', async (t) => {
         [
           "thing",
           [
-            "id",
-            "da3",
-            "name",
-            "dong"
+            [
+              "id",
+              "da3",
+              "id",
+              "da3",
+              "name",
+              "dong"
+            ]
           ]
         ]
       ]
@@ -1263,10 +1298,14 @@ test.serial('wildcard find with exclusions', async (t) => {
         [
           'thing',
           [
-            'id',
-            'da3',
-            'name',
-            'dong',
+            [
+              'id',
+              'da3',
+              'id',
+              'da3',
+              'name',
+              'dong',
+            ]
           ]
         ]
       ]

--- a/client/test/edgeFieldNested.ts
+++ b/client/test/edgeFieldNested.ts
@@ -112,12 +112,16 @@ test.serial('retrieving nested refs with fields arg', async (t) => {
       [
         "id",
         "tx0",
+        "id",
+        "tx0",
         "name",
         "file0.txt",
         "type",
         "file"
       ],
       [
+        "id",
+        "tx1",
         "id",
         "tx1",
         "name",
@@ -185,8 +189,8 @@ test.serial('retrieving nested refs with fields arg', async (t) => {
   t.deepEqual(res5[0][1][4], 'docs')
   t.deepEqual(res5[0][1][5][0][2], 'mirrors')
   t.deepEqual(res5[0][1][5][0][3].length, 2)
-  t.deepEqual(res5[0][1][5][0][3][0].length, 6)
-  t.deepEqual(res5[0][1][5][0][3][1].length, 6)
+  t.deepEqual(res5[0][1][5][0][3][0].length, 8)
+  t.deepEqual(res5[0][1][5][0][3][1].length, 8)
   t.deepEqual(res5[1][1][0], 'docs')
   t.deepEqual(res5[1][1][1][0][0], 'id')
   t.deepEqual(res5[1][1][1][1][0], 'id')
@@ -198,8 +202,8 @@ test.serial('retrieving nested refs with fields arg', async (t) => {
   t.deepEqual(res5[1][1][4], 'docs')
   t.deepEqual(res5[1][1][5][0][2], 'mirrors')
   t.deepEqual(res5[1][1][5][0][3].length, 2)
-  t.deepEqual(res5[1][1][5][0][3][0].length, 6)
-  t.deepEqual(res5[1][1][5][0][3][1].length, 6)
+  t.deepEqual(res5[1][1][5][0][3][0].length, 8)
+  t.deepEqual(res5[1][1][5][0][3][1].length, 8)
 
   const res6 = await client.get({
     files: {

--- a/client/test/reference.ts
+++ b/client/test/reference.ts
@@ -542,6 +542,7 @@ test.serial('list of simple singular reference', async (t) => {
     },
   })
 
+  console.log(JSON.stringify(result, null, 2))
   t.deepEqual(result, {
     children: [
       {

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -180,8 +180,6 @@ static int send_edge_field(
             next_prefix_len = 0;
         }
 
-        RedisModuleString *exclude_id = RedisModule_CreateStringPrintf(ctx, "id");
-
         struct SVectorIterator it;
         struct SelvaHierarchyNode *dst_node;
 
@@ -213,7 +211,7 @@ static int send_edge_field(
                 /*
                  * RFE Excluding fields doesn't currently work with wildcard.
                  */
-                res = send_all_node_data_fields(ctx, lang, hierarchy, dst_node, NULL, 0, exclude_id);
+                res = send_all_node_data_fields(ctx, lang, hierarchy, dst_node, NULL, 0, NULL);
                 if (next_prefix_str) {
                     RedisModule_ReplySetArrayLength(ctx, res > 0 ? res : 0);
                 } else if (res >= 0) {


### PR DESCRIPTION
Apparently this only worked with strings.