### PR TITLE
Remove node-fetch

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,6 @@
     "get-port": "^5.1.1",
     "husky": "^5.0.9",
     "lint-staged": "^10.5.4",
-    "node-fetch": "^2.6.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.4",
     "typescript-to-lua": "^0.30.1"

--- a/client/src/get/validate/aggregate.ts
+++ b/client/src/get/validate/aggregate.ts
@@ -10,8 +10,6 @@ import validateFind from './find'
 import validateSort from './sort'
 import { isTraverseByType, isTraverseOptions } from '../utils'
 
-// import fetch from 'node-fetch'
-
 // TODO: more concurrency for fetching
 async function evaluateTextSearch(
   filters: Filter[],
@@ -53,23 +51,24 @@ async function evaluateTextSearch(
     const results: string[][] = await Promise.all(
       textSearches.map(async (f: Filter | string[]) => {
         // TODO: replace hard coded url and port
-        if (Array.isArray(f)) {
-        } else {
-          const resp = await fetch('http://localhost:33333/get', {
-            method: 'POST',
-            headers: {
-              'content-type': 'application/json',
-            },
-            body: JSON.stringify({
-              $searchString: f.$value,
-              $field: f.$field,
-              $language: language, // FIXME
-            }),
-          })
+        //if (Array.isArray(f)) {
+        //} else {
+        //  const resp = await fetch('http://localhost:33333/get', {
+        //    method: 'POST',
+        //    headers: {
+        //      'content-type': 'application/json',
+        //    },
+        //    body: JSON.stringify({
+        //      $searchString: f.$value,
+        //      $field: f.$field,
+        //      $language: language, // FIXME
+        //    }),
+        //  })
 
-          const ids = await resp.json()
-          return ids
-        }
+        //  const ids = await resp.json()
+        //  return ids
+        //}
+        return []
       })
     )
 

--- a/client/src/get/validate/find.ts
+++ b/client/src/get/validate/find.ts
@@ -8,8 +8,6 @@ import { get } from '..'
 import { addExtraQuery, ExtraQueries } from '.'
 import { isTraverseByType, isTraverseOptions } from '../utils'
 
-// import fetch from 'node-fetch'
-
 // TODO: more concurrency for fetching
 async function evaluateTextSearch(
   filters: Filter[],

--- a/client/test/findText.ts
+++ b/client/test/findText.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import fetch from 'node-fetch'
 import { connect } from '../src/index'
 import { start, startTextServer } from '@saulx/selva-server'
 import { wait } from './assertions'
@@ -277,33 +276,33 @@ test.serial('find fields with a substring match', async (t) => {
 })
 
 test.serial.failing('hhnn', async (t) => {
-  let resp = await fetch(`http://localhost:${txtPort}/set`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      $id: 'maga',
-      $searchString: 'hello world',
-      $field: 'title',
-      $language: 'en',
-    }),
-  })
+  //let resp = await fetch(`http://localhost:${txtPort}/set`, {
+  //  method: 'POST',
+  //  headers: {
+  //    'content-type': 'application/json',
+  //  },
+  //  body: JSON.stringify({
+  //    $id: 'maga',
+  //    $searchString: 'hello world',
+  //    $field: 'title',
+  //    $language: 'en',
+  //  }),
+  //})
 
-  console.log('YES', await resp.text())
+  //console.log('YES', await resp.text())
 
-  resp = await fetch(`http://localhost:${txtPort}/set`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      $id: 'masa',
-      $searchString: 'hell song',
-      $field: 'title',
-      $language: 'en',
-    }),
-  })
+  //resp = await fetch(`http://localhost:${txtPort}/set`, {
+  //  method: 'POST',
+  //  headers: {
+  //    'content-type': 'application/json',
+  //  },
+  //  body: JSON.stringify({
+  //    $id: 'masa',
+  //    $searchString: 'hell song',
+  //    $field: 'title',
+  //    $language: 'en',
+  //  }),
+  //})
 
   console.log('YES', await resp.text())
 

--- a/server/package.json
+++ b/server/package.json
@@ -69,7 +69,6 @@
     "flexsearch": "^0.6.32",
     "get-port": "^5.1.1",
     "mkdirp": "1.0.4",
-    "node-fetch": "^2.6.1",
     "os-utils": "^0.0.14",
     "pg": "8.7.1",
     "pidusage": "^2.0.21",


### PR DESCRIPTION
Apparently `node-fetch` is only used for text search, which
doesn't currently exist as a feature. If we need `fetch` in the
future, then we can probably use the built-in `fetch` in Node.js
17/18.