### PR TITLE
Rpn conditional forward jump and optimizations

### DIFF
--- a/client/src/connection/redisClientExtensions.ts
+++ b/client/src/connection/redisClientExtensions.ts
@@ -67,6 +67,9 @@ const selva_commands = [
   'selva.index.list',
   'selva.index.new',
   'selva.index.del',
+  'selva.rpn.evalbool',
+  'selva.rpn.evaldouble',
+  'selva.rpn.evalstring',
 ]
 
 redis.RedisClient.prototype.on_info_cmd = function (err, res) {

--- a/client/src/redis/methods/generator/index.js
+++ b/client/src/redis/methods/generator/index.js
@@ -76,6 +76,9 @@ redis.add_command('selva.subscriptions.refresh')
 redis.add_command('selva.index.list')
 redis.add_command('selva.index.new')
 redis.add_command('selva.index.del')
+redis.add_command('selva.rpn.evalbool')
+redis.add_command('selva.rpn.evaldouble')
+redis.add_command('selva.rpn.evalstring')
 const proto = redis.RedisClient.prototype
 for (const key in redis.RedisClient.prototype) {
   if (/[A-Z]/.test(key[0]) && typeof proto[key] === 'function') {

--- a/client/src/redis/methods/index.ts
+++ b/client/src/redis/methods/index.ts
@@ -3982,6 +3982,51 @@ async selva_index_del(opts: any, ...args: args): Promise<any> {
   }
 }
 
+
+async selva_rpn_evalbool(opts: ServerSelector, ...args: args): Promise<any>
+async selva_rpn_evalbool(...args: args): Promise<any>
+async selva_rpn_evalbool(opts: any, ...args: args): Promise<any> {
+  if (typeof opts === 'object') {
+    return new Promise((resolve, reject) => {
+      this.addCommandToQueue({ command: 'selva_rpn_evalbool', args, resolve, reject }, opts)
+    })
+  } else {
+    return new Promise((resolve, reject) => {
+      this.addCommandToQueue({ command: 'selva_rpn_evalbool', args: [opts, ...args], resolve, reject })
+    })
+  }
+}
+
+
+async selva_rpn_evaldouble(opts: ServerSelector, ...args: args): Promise<any>
+async selva_rpn_evaldouble(...args: args): Promise<any>
+async selva_rpn_evaldouble(opts: any, ...args: args): Promise<any> {
+  if (typeof opts === 'object') {
+    return new Promise((resolve, reject) => {
+      this.addCommandToQueue({ command: 'selva_rpn_evaldouble', args, resolve, reject }, opts)
+    })
+  } else {
+    return new Promise((resolve, reject) => {
+      this.addCommandToQueue({ command: 'selva_rpn_evaldouble', args: [opts, ...args], resolve, reject })
+    })
+  }
+}
+
+
+async selva_rpn_evalstring(opts: ServerSelector, ...args: args): Promise<any>
+async selva_rpn_evalstring(...args: args): Promise<any>
+async selva_rpn_evalstring(opts: any, ...args: args): Promise<any> {
+  if (typeof opts === 'object') {
+    return new Promise((resolve, reject) => {
+      this.addCommandToQueue({ command: 'selva_rpn_evalstring', args, resolve, reject }, opts)
+    })
+  } else {
+    return new Promise((resolve, reject) => {
+      this.addCommandToQueue({ command: 'selva_rpn_evalstring', args: [opts, ...args], resolve, reject })
+    })
+  }
+}
+
 }
 
 export default RedisMethods

--- a/client/test/rpn.ts
+++ b/client/test/rpn.ts
@@ -1,0 +1,129 @@
+import test from 'ava'
+import { connect } from '../src/index'
+import { start } from '@saulx/selva-server'
+import './assertions'
+import { wait } from './assertions'
+import getPort from 'get-port'
+
+let srv
+let port: number
+
+test.before(async (t) => {
+  port = await getPort()
+  srv = await start({
+    port,
+  })
+  await wait(100)
+})
+
+test.after(async (t) => {
+  const client = connect({ port })
+  //await client.delete('root')
+  await client.destroy()
+  await srv.destroy()
+  await t.connectionsAreEmpty()
+})
+
+test.serial('eval boolean expressions', async (t) => {
+  const client = connect({ port })
+
+  // test ternary
+  const expr1 = '#1 #0 @1 T'
+  t.deepEqual(
+    await client.redis.selva_rpn_evalbool('node123456', expr1, '0'),
+    1
+  )
+  t.deepEqual(
+    await client.redis.selva_rpn_evalbool('node123456', expr1, '1'),
+    0
+  )
+
+  // Test duplicate
+  t.deepEqual(
+    await client.redis.selva_rpn_evalbool('node123456', '#1 R A'),
+    1
+  )
+
+  await client.destroy()
+})
+
+test.serial('eval to double', async (t) => {
+  const client = connect({ port })
+
+  // Test ternary
+  const expr1 = '@2 #1 A @2 #2 A @1 T'
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', expr1, '0', '3')),
+    4
+  )
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', expr1, '1', '3')),
+    5
+  )
+
+  // Test duplicate
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', '#1 R A')),
+    2
+  )
+
+  // Test swap, duplicate, and forward jump
+  const expr2 = '@1 R #5 S I >2 #0 D'
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', expr2, '3')),
+    0
+  )
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', expr2, '6')),
+    6
+  )
+
+  // Drop
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', '#3 #2 U')),
+    3
+  )
+
+  // drop, forward jump, and swap
+  const expr3 = '@2 @1 R #5 H >1 S U'
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', expr3, '3', '6')),
+    3
+  )
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', expr3, '10', '6')),
+    6
+  )
+
+  // rotate
+  //   ab - bc
+  // = 4 * (10 - 5)
+  const expr4 = '@3 @2 @1 V B D'
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', expr4, '10', '4', '5')),
+    4 * (10 - 5)
+  )
+
+  await client.destroy()
+})
+
+test.serial('eval to string', async (t) => {
+  const client = connect({ port })
+
+  t.deepEqual(
+    await client.redis.selva_rpn_evalstring('node123456', '"hello"'),
+    'hello'
+  )
+
+  const expr1 = '@1 #1 A #2 F L >3 "true" #1 >1 "false"'
+  t.deepEqual(
+    await client.redis.selva_rpn_evalstring('node123456', expr1, '1'),
+    'true'
+  )
+  t.deepEqual(
+    await client.redis.selva_rpn_evalstring('node123456', expr1, '0'),
+    'false'
+  )
+
+  await client.destroy()
+})

--- a/client/test/rpn.ts
+++ b/client/test/rpn.ts
@@ -62,12 +62,14 @@ test.serial('eval to double', async (t) => {
   )
 
   // Test duplicate
+  // 1 + 1
   t.deepEqual(
     Number(await client.redis.selva_rpn_evaldouble('node123456', '#1 R A')),
     2
   )
 
   // Test swap, duplicate, and forward jump
+  // a > 5 ? 0 : a
   const expr2 = '@1 R #5 S I >2 #0 D'
   t.deepEqual(
     Number(await client.redis.selva_rpn_evaldouble('node123456', expr2, '3')),
@@ -85,6 +87,7 @@ test.serial('eval to double', async (t) => {
   )
 
   // drop, forward jump, and swap
+  // a > 5 ? 0 : a
   const expr3 = '@2 @1 R #5 H >1 S U'
   t.deepEqual(
     Number(await client.redis.selva_rpn_evaldouble('node123456', expr3, '3', '6')),
@@ -122,6 +125,7 @@ test.serial('eval to string', async (t) => {
     'hello'
   )
 
+  // a + 1 == 2 ? "true" : "false"
   const expr1 = '@1 #1 A #2 F L >3 "true" #1 >1 "false"'
   t.deepEqual(
     await client.redis.selva_rpn_evalstring('node123456', expr1, '1'),

--- a/client/test/rpn.ts
+++ b/client/test/rpn.ts
@@ -95,10 +95,17 @@ test.serial('eval to double', async (t) => {
     6
   )
 
+  // Over
+  // a * (a + b)
+  t.deepEqual(
+    Number(await client.redis.selva_rpn_evaldouble('node123456', '#2 #3 V A D')),
+    10
+  )
+
   // rotate
   //   ab - bc
   // = 4 * (10 - 5)
-  const expr4 = '@3 @2 @1 V B D'
+  const expr4 = '@3 @2 @1 W B D'
   t.deepEqual(
     Number(await client.redis.selva_rpn_evaldouble('node123456', expr4, '10', '4', '5')),
     4 * (10 - 5)

--- a/query-ast-parser/src/ast2rpn.ts
+++ b/query-ast-parser/src/ast2rpn.ts
@@ -66,12 +66,7 @@ export default function ast2rpn(
       types[f.$value] &&
       types[f.$value].prefix
     ) {
-      const prefix = types[f.$value].prefix
-
-      const valueId = regIndex
-      reg[regIndex++] = prefix
-
-      out += ` $${valueId} e`
+      out += ` "${types[f.$value].prefix}" e`
       if (f.isNecessary) {
         out += ' P'
       }
@@ -157,8 +152,6 @@ export default function ast2rpn(
       }
     } else if (vType == 'boolean') {
       const fieldId = fieldNameToReg(f.$field)
-      const valueId = regIndex
-      reg[regIndex++] = f.$value ? '1' : '0'
 
       const op = opMapNumber[f.$operator]
       if (!op) {
@@ -166,7 +159,7 @@ export default function ast2rpn(
         // TODO error
       }
 
-      out += ` @${valueId} $${fieldId} g ${op}`
+      out += ` #${f.$value ? '1' : '0'} $${fieldId} g ${op}`
     } else if (f.$operator == '..') {
       const fieldId = fieldNameToReg(f.$field)
       let valueId1: string | number = regIndex

--- a/query-ast-parser/src/ast2rpn.ts
+++ b/query-ast-parser/src/ast2rpn.ts
@@ -39,7 +39,19 @@ export default function ast2rpn(
 ): Rpn {
   let out = ''
   let reg: string[] = []
+
   let regIndex = 1
+  const regMap = {}
+  const fieldNameToReg = (fieldName: string) => {
+    if (regMap[fieldName]) {
+      return regMap[fieldName]
+    } else {
+      const i = regIndex++
+      reg[i] = fieldName
+      regMap[fieldName] = i
+      return i
+    }
+  }
 
   function ast2rpnFilter(
     types: Record<string, { prefix?: string }>,
@@ -78,14 +90,12 @@ export default function ast2rpn(
     }
 
     if (f.$operator == 'exists') {
-      const fieldId = regIndex
-      reg[regIndex++] = f.$field
+      const fieldId = fieldNameToReg(f.$field)
 
       out += ` $${fieldId} h`
       return
     } else if (f.$operator == 'notExists') {
-      const fieldId = regIndex
-      reg[regIndex++] = f.$field
+      const fieldId = fieldNameToReg(f.$field)
 
       out += ` $${fieldId} h L`
       return
@@ -114,8 +124,7 @@ export default function ast2rpn(
       )
       return
     } else if (vType == 'string' || vType == 'number') {
-      const fieldId = regIndex
-      reg[regIndex++] = f.$field
+      const fieldId = fieldNameToReg(f.$field)
 
       let valueId: string | number = regIndex
       let isNowValue: boolean = false
@@ -147,8 +156,7 @@ export default function ast2rpn(
         out += ` $${valueId} $${fieldId} f ${op}`
       }
     } else if (vType == 'boolean') {
-      const fieldId = regIndex
-      reg[regIndex++] = f.$field
+      const fieldId = fieldNameToReg(f.$field)
       const valueId = regIndex
       reg[regIndex++] = f.$value ? '1' : '0'
 
@@ -160,8 +168,7 @@ export default function ast2rpn(
 
       out += ` @${valueId} $${fieldId} g ${op}`
     } else if (f.$operator == '..') {
-      const fieldId = regIndex
-      reg[regIndex++] = f.$field
+      const fieldId = fieldNameToReg(f.$field)
       let valueId1: string | number = regIndex
       let isNowValue1: boolean = false
 

--- a/redis/parser/lib/parser.js
+++ b/redis/parser/lib/parser.js
@@ -197,6 +197,7 @@ function parseBinaryBuffer (parser) {
 function parseError (parser) {
   var string = parseSimpleString(parser)
   if (string !== undefined) {
+    console.log(string)
     if (parser.optionReturnBuffers === true) {
       string = string.toString()
     }

--- a/server/modules/selva/doc/hierarchy/expressions.md
+++ b/server/modules/selva/doc/hierarchy/expressions.md
@@ -95,11 +95,14 @@ User registers start from index 1, and register number 0 is reserved for the cur
 
 Type codes used in the documentation:
 - s: string
-- n: number
+- n: number or boolean
 - z: set or set-like
 - Z: set
 - O: object
 - X: any
+- <>: nothing
+
+`=>` following by a type code shows what is pushed to the stack.
 
 **Arithmetic operators**
 
@@ -130,9 +133,19 @@ Type codes used in the documentation:
 | `M`      | `(n, n) => n`    | Logical AND operator.                   | `#1 #1 M => 1`           |
 | `N`      | `(n, n) => n`    | Logical OR operator.                    | `#0 #1 N => 1`           |
 | `O`      | `(n, n) => n`    | Logical XOR operator. `(!!a ^ !!b)`     | `#1 #1 O => 0`           |
+| `T`      | `(n, X, X) => X` | Ternary, `a ? b : c`.                   | `$3 $2 @1 T => X`        |
+
+**Control flow operators**
+
+| Operator | Operands         | Description                             | Example (expr => result) |
+| -------- | ---------------- | --------------------------------------- | ------------------------ |
+| `>`      | `(n) => <>`      | Conditional jump forward.               | `#1 >2 => <>`            |
 | `P`      | `(X) => n`       | Necessity `□a`. (It's necessary that a) | `#0 P #1 N => 0`         |
 | `Q`      | `(X) => n`       | Possibly `◇a`.                          | `#1 Q #0 M => 1`         |
-| `T`      | `(n, X, X) => X` | Ternary, `a ? b : c`.                   | `$3 $2 @1 T => X`        |
+
+The conditional jump operator `>` jumps over specified number of tokens that is
+a compile time constant. The first an only argument popped from the stack is the
+boolean condition that decides whether the operator will execute a jump.
 
 `P` and `Q` are short circuiting operators and don't represent classical modal
 logic. The `P` operator bails out immediately if the operand is not truthy and
@@ -161,11 +174,11 @@ expressions, we'll get the following result:
 
 Therefore, neither of these yields the expected result.
 
-**Set Operations**
+**Set operations**
 
-| Operator | Operands         | Description                           | Example (expr => result) |
-| -------- | ---------------- | ------------------------------------- | ------------------------ |
-| `z`      | `(Z, Z) => Z`    | Union of A and B.                     | `B A a => C`             |
+| Operator | Operands         | Description                             | Example (expr => result) |
+| -------- | ---------------- | --------------------------------------- | ------------------------ |
+| `z`      | `(Z, Z) => Z`    | Union of A and B.                       | `B A a => C`             |
 
 **Functions**
 

--- a/server/modules/selva/doc/hierarchy/expressions.md
+++ b/server/modules/selva/doc/hierarchy/expressions.md
@@ -142,6 +142,7 @@ Type codes used in the documentation:
 | `R`      | `(X) => X, X`    | Duplicate the last values in the stack. | `#1 R => 1, 1`           |
 | `S`      | `(X, X) => X, X` | Swap the last two values in the stack.  | `#1 #2 S => #1, #2`      |
 | `U`      | `(X) => {}`      | Drop, discard the top stack value.      | `#1 #2 D => #1`          |
+| `V`      | `(X, X, X) => 3X | Rotate top three values in the stack.   | `#1 #2 #3 V => #2 #3 #1` |
 
 **Control flow operators**
 

--- a/server/modules/selva/doc/hierarchy/expressions.md
+++ b/server/modules/selva/doc/hierarchy/expressions.md
@@ -139,6 +139,8 @@ Type codes used in the documentation:
 
 | Operator | Operands         | Description                             | Example (expr => result) |
 | -------- | ---------------- | --------------------------------------- | ------------------------ |
+| `R`      | `(X) => X, X`    | Duplicate the last operand in stack.    | `#1 R => 1, 1`           |
+| `S`      | `(X, X) => X, X` | Swap the last two operands in stack.    | `#1 #2 S => #1, #2`      |
 | `>`      | `(n) => <>`      | Conditional jump forward.               | `#1 >2 => <>`            |
 | `P`      | `(X) => n`       | Necessity `□a`. (It's necessary that a) | `#0 P #1 N => 0`         |
 | `Q`      | `(X) => n`       | Possibly `◇a`.                          | `#1 Q #0 M => 1`         |

--- a/server/modules/selva/doc/hierarchy/expressions.md
+++ b/server/modules/selva/doc/hierarchy/expressions.md
@@ -137,12 +137,13 @@ Type codes used in the documentation:
 
 **Stack manipulation operators**
 
-| Operator | Operands         | Description                             | Example (expr => result) |
-| -------- | ---------------- | --------------------------------------- | ------------------------ |
-| `R`      | `(X) => X, X`    | Duplicate the last values in the stack. | `#1 R => 1, 1`           |
-| `S`      | `(X, X) => X, X` | Swap the last two values in the stack.  | `#1 #2 S => #1, #2`      |
-| `U`      | `(X) => {}`      | Drop, discard the top stack value.      | `#1 #2 D => #1`          |
-| `V`      | `(X, X, X) => 3X | Rotate top three values in the stack.   | `#1 #2 #3 V => #2 #3 #1` |
+| Operator | Operands            | Description                                  | Example (expr => result) |
+| -------- | ------------------- | -------------------------------------------- | ------------------------ |
+| `R`      | `(X) => X, X`       | Duplicate the last values in the stack.      | `#1 R => 1, 1`           |
+| `S`      | `(X, X) => X, X`    | Swap the last two values in the stack.       | `#1 #2 S => #1, #2`      |
+| `U`      | `(X) => {}`         | Drop, discard the top stack value.           | `#1 #2 D => #1`          |
+| `V`      | `(X1, X2) => X1, X2, X1` | Copy the value under top of the stack.  | `#1 #2 V => #1 #2 #1`    |
+| `W`      | `(X1, X2, X3) => X2 X3 X1` | Rotate top three values in the stack. | `#1 #2 #3 W => #2 #3 #1` |
 
 **Control flow operators**
 

--- a/server/modules/selva/doc/hierarchy/expressions.md
+++ b/server/modules/selva/doc/hierarchy/expressions.md
@@ -135,12 +135,18 @@ Type codes used in the documentation:
 | `O`      | `(n, n) => n`    | Logical XOR operator. `(!!a ^ !!b)`     | `#1 #1 O => 0`           |
 | `T`      | `(n, X, X) => X` | Ternary, `a ? b : c`.                   | `$3 $2 @1 T => X`        |
 
+**Stack manipulation operators**
+
+| Operator | Operands         | Description                             | Example (expr => result) |
+| -------- | ---------------- | --------------------------------------- | ------------------------ |
+| `R`      | `(X) => X, X`    | Duplicate the last values in the stack. | `#1 R => 1, 1`           |
+| `S`      | `(X, X) => X, X` | Swap the last two values in the stack.  | `#1 #2 S => #1, #2`      |
+| `U`      | `(X) => {}`      | Drop, discard the top stack value.      | `#1 #2 D => #1`          |
+
 **Control flow operators**
 
 | Operator | Operands         | Description                             | Example (expr => result) |
 | -------- | ---------------- | --------------------------------------- | ------------------------ |
-| `R`      | `(X) => X, X`    | Duplicate the last operand in stack.    | `#1 R => 1, 1`           |
-| `S`      | `(X, X) => X, X` | Swap the last two operands in stack.    | `#1 #2 S => #1, #2`      |
 | `>`      | `(n) => <>`      | Conditional jump forward.               | `#1 >2 => <>`            |
 | `P`      | `(X) => n`       | Necessity `□a`. (It's necessary that a) | `#0 P #1 N => 0`         |
 | `Q`      | `(X) => n`       | Possibly `◇a`.                          | `#1 Q #0 M => 1`         |

--- a/server/modules/selva/doc/hierarchy/expressions.md
+++ b/server/modules/selva/doc/hierarchy/expressions.md
@@ -137,13 +137,13 @@ Type codes used in the documentation:
 
 **Stack manipulation operators**
 
-| Operator | Operands            | Description                                  | Example (expr => result) |
-| -------- | ------------------- | -------------------------------------------- | ------------------------ |
-| `R`      | `(X) => X, X`       | Duplicate the last values in the stack.      | `#1 R => 1, 1`           |
-| `S`      | `(X, X) => X, X`    | Swap the last two values in the stack.       | `#1 #2 S => #1, #2`      |
-| `U`      | `(X) => {}`         | Drop, discard the top stack value.           | `#1 #2 D => #1`          |
-| `V`      | `(X1, X2) => X1, X2, X1` | Copy the value under top of the stack.  | `#1 #2 V => #1 #2 #1`    |
-| `W`      | `(X1, X2, X3) => X2 X3 X1` | Rotate top three values in the stack. | `#1 #2 #3 W => #2 #3 #1` |
+| Operator | Operands             | Description                                  | Example (expr => result) |
+| -------- | -------------------- | -------------------------------------------- | ------------------------ |
+| `R`      | `(X) => X, X`        | Duplicate the last values in the stack.      | `#1 R => 1, 1`           |
+| `S`      | `(X1, X2) => X2, X1` | Swap the last two values in the stack.       | `#1 #2 S => #1, #2`      |
+| `U`      | `(X) => {}`          | Drop, discard the top stack value.           | `#1 #2 D => #1`          |
+| `V`      | `(X1, X2) => X1, X2, X1`   | Copy the value under top of the stack. | `#1 #2 V => #1 #2 #1`    |
+| `W`      | `(X1, X2, X3) => X2 X3 X1` | Rotate top three values in the stack.  | `#1 #2 #3 W => #2 #3 #1` |
 
 **Control flow operators**
 

--- a/server/modules/selva/include/rpn.h
+++ b/server/modules/selva/include/rpn.h
@@ -39,7 +39,7 @@ struct rpn_ctx {
     struct SelvaHierarchy *hierarchy;
     struct SelvaHierarchyNode *node; /*!< A pointer to the current hierarchy node set with rpn_set_hierarchy_node(). */
     struct SelvaObject *obj; /*!< Selva object of the current node. */
-    struct RedisModuleString *rms_field;  /*!< This holds the name of the currently accessed field. */
+    struct RedisModuleString *rms;  /*!< This is a specially crafted rms that can be modified within RPN. */
     struct rpn_operand **reg;
     struct rpn_operand *stack[RPN_MAX_D];
 };

--- a/server/modules/selva/include/rpn.h
+++ b/server/modules/selva/include/rpn.h
@@ -9,6 +9,9 @@
  */
 #define RPN_MAX_TOKEN_SIZE              (1 + sizeof(void *))
 
+/**
+ * RPN Errors.
+ */
 enum rpn_error {
     RPN_ERR_OK = 0,     /*!< No error. */
     RPN_ERR_ENOMEM,     /*!< Out of memory. */
@@ -33,10 +36,14 @@ struct SelvaHierarchyNode;
 struct SelvaSet;
 struct rpn_operand;
 
+/**
+ * RPN Context.
+ * The same context can be used multiple times ones created and initialized.
+ */
 struct rpn_ctx {
-    int depth;
-    int nr_reg;
-    struct SelvaHierarchy *hierarchy;
+    int depth; /*!< Stack pointer, current stack depth. */
+    int nr_reg; /*!< Number of registers allocated. */
+    struct SelvaHierarchy *hierarchy; /*!< A pointer to the associated hierarchy. */
     struct SelvaHierarchyNode *node; /*!< A pointer to the current hierarchy node set with rpn_set_hierarchy_node(). */
     struct SelvaObject *obj; /*!< Selva object of the current node. */
     struct RedisModuleString *rms;  /*!< This is a specially crafted rms that can be modified within RPN. */
@@ -44,6 +51,9 @@ struct rpn_ctx {
     struct rpn_operand *reg[0]; /*!< RPN registers. */
 };
 
+/**
+ * Compiled token in the expression.
+ */
 typedef char rpn_token[RPN_MAX_TOKEN_SIZE];
 
 /**
@@ -59,7 +69,15 @@ struct rpn_expression {
 
 extern const char *rpn_str_error[RPN_ERR_LAST];
 
+/**
+ * Initialize an RPN context with nr_reg registers.
+ */
 struct rpn_ctx *rpn_init(int nr_reg);
+
+/**
+ * Destroy an RPN context.
+ * @param ctx is a pointer t o an RPN context created with rpn_init().
+ */
 void rpn_destroy(struct rpn_ctx *ctx);
 
 /**
@@ -80,11 +98,36 @@ static inline void rpn_set_obj(struct rpn_ctx *ctx, struct SelvaObject *obj) {
 }
 
 enum rpn_error rpn_set_reg(struct rpn_ctx *ctx, size_t i, const char *s, size_t size, unsigned flags);
-enum rpn_error rpn_set_reg_rm(struct rpn_ctx *ctx, size_t i, struct RedisModuleString *rms);
+
+/**
+ * Set a register value from a RedisModuleString.
+ * The value is copied and no pointer to rms is held.
+ */
+enum rpn_error rpn_set_reg_rms(struct rpn_ctx *ctx, size_t i, struct RedisModuleString *rms);
+
+/**
+ * Set a register value as a pointer to a SelvaObject.
+ */
 enum rpn_error rpn_set_reg_slvobj(struct rpn_ctx *ctx, size_t i, struct SelvaObject *obj, unsigned flags);
+
+/**
+ * Set a register value as a pointer to a SelvaSet.
+ */
 enum rpn_error rpn_set_reg_slvset(struct rpn_ctx *ctx, size_t i, struct SelvaSet *set, unsigned flags);
+
+/**
+ * Compile an RPN expression.
+ * @param input is pointer to a nul-terminated RPN expression.
+ * @returns A compiled expression.
+ */
 struct rpn_expression *rpn_compile(const char *input);
+
+/**
+ * Destroy a compiled RPN expression.
+ * @param expr is a pointer to an expression created with rpn_compile().
+ */
 void rpn_destroy_expression(struct rpn_expression *expr);
+
 enum rpn_error rpn_bool(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ctx, const struct rpn_expression *expr, int *out);
 enum rpn_error rpn_double(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ctx, const struct rpn_expression *expr, double *out);
 enum rpn_error rpn_integer(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ctx, const struct rpn_expression *expr, long long *out);

--- a/server/modules/selva/include/rpn.h
+++ b/server/modules/selva/include/rpn.h
@@ -40,8 +40,8 @@ struct rpn_ctx {
     struct SelvaHierarchyNode *node; /*!< A pointer to the current hierarchy node set with rpn_set_hierarchy_node(). */
     struct SelvaObject *obj; /*!< Selva object of the current node. */
     struct RedisModuleString *rms;  /*!< This is a specially crafted rms that can be modified within RPN. */
-    struct rpn_operand **reg;
-    struct rpn_operand *stack[RPN_MAX_D];
+    struct rpn_operand *stack[RPN_MAX_D]; /*!< Execution stack. */
+    struct rpn_operand *reg[0]; /*!< RPN registers. */
 };
 
 typedef char rpn_token[RPN_MAX_TOKEN_SIZE];

--- a/server/modules/selva/include/rpn.h
+++ b/server/modules/selva/include/rpn.h
@@ -7,7 +7,7 @@
  * An operand in a compiled expression cannot exceed this length.
  * The size of a literal operand is not limited by this setting.
  */
-#define RPN_MAX_TOKEN_SIZE              6
+#define RPN_MAX_TOKEN_SIZE              (1 + sizeof(void *))
 
 enum rpn_error {
     RPN_ERR_OK = 0,     /*!< No error. */

--- a/server/modules/selva/include/traversal_order.h
+++ b/server/modules/selva/include/traversal_order.h
@@ -44,7 +44,7 @@ int SelvaTraversalOrder_InitOrderResult(SVector *order_result, enum SelvaResultO
  * function should be called with a ctx too. Alternatively the order_result
  * SVector can be declared with SVECTOR_AUTOFREE().
  */
-void SelvaTraversalOrder_DestroyOrderResult(RedisModuleCtx *ctx, SVector *order_result);
+void SelvaTraversalOrder_DestroyOrderResult(struct RedisModuleCtx *ctx, SVector *order_result);
 
 /**
  * Create a new TraversalOrderItem that can be sorted.
@@ -55,7 +55,7 @@ struct TraversalOrderItem *SelvaTraversalOrder_CreateOrderItem(
         struct RedisModuleString *lang,
         struct SelvaHierarchyNode *node,
         const struct RedisModuleString *order_field);
-void SelvaTraversalOrder_DestroyOrderItem(RedisModuleCtx *ctx, struct TraversalOrderItem *item);
+void SelvaTraversalOrder_DestroyOrderItem(struct RedisModuleCtx *ctx, struct TraversalOrderItem *item);
 struct TraversalOrderItem *SelvaTraversalOrder_CreateObjectBasedOrderItem(
         struct RedisModuleCtx *ctx,
         struct RedisModuleString *lang,

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -895,6 +895,12 @@ static enum rpn_error rpn_op_ternary(struct RedisModuleCtx *redis_ctx __unused, 
     }
 }
 
+static enum rpn_error rpn_op_drop(struct RedisModuleCtx *redis_crx __unused, struct rpn_ctx *ctx) {
+    OPERAND(ctx, a);
+
+    return RPN_ERR_OK;
+}
+
 static enum rpn_error rpn_op_exists(struct RedisModuleCtx *redis_ctx __unused, struct rpn_ctx *ctx) {
     int exists;
     OPERAND(ctx, field);
@@ -1284,7 +1290,7 @@ static rpn_fp funcs[] = {
     rpn_op_dup,     /* R */
     rpn_op_swap,    /* S */
     rpn_op_ternary, /* T spare */
-    rpn_op_abo,     /* U spare */
+    rpn_op_drop,    /* U */
     rpn_op_abo,     /* V spare */
     rpn_op_abo,     /* W spare */
     rpn_op_abo,     /* X */

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -901,6 +901,23 @@ static enum rpn_error rpn_op_drop(struct RedisModuleCtx *redis_crx __unused, str
     return RPN_ERR_OK;
 }
 
+static enum rpn_error rpn_op_rot(struct RedisModuleCtx *redis_crx __unused, struct rpn_ctx *ctx) {
+    enum rpn_error err;
+    OPERAND(ctx, a);
+    OPERAND(ctx, b);
+    OPERAND(ctx, c);
+
+    err = push(ctx, b);
+    if (err) {
+        return err;
+    }
+    err = push(ctx, c);
+    if (err) {
+        return err;
+    }
+    return push(ctx, a);
+}
+
 static enum rpn_error rpn_op_exists(struct RedisModuleCtx *redis_ctx __unused, struct rpn_ctx *ctx) {
     int exists;
     OPERAND(ctx, field);
@@ -1289,9 +1306,9 @@ static rpn_fp funcs[] = {
     rpn_op_possib,  /* Q */
     rpn_op_dup,     /* R */
     rpn_op_swap,    /* S */
-    rpn_op_ternary, /* T spare */
+    rpn_op_ternary, /* T */
     rpn_op_drop,    /* U */
-    rpn_op_abo,     /* V spare */
+    rpn_op_rot,     /* V */
     rpn_op_abo,     /* W spare */
     rpn_op_abo,     /* X */
     rpn_op_abo,     /* Y */

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -527,10 +527,6 @@ enum rpn_error rpn_set_reg_rm(struct rpn_ctx *ctx, size_t i, RedisModuleString *
     char *arg;
 
     arg = RedisModule_Alloc(size);
-    if (!arg) {
-        return RPN_ERR_ENOMEM;
-    }
-
     memcpy(arg, rms_str, size);
     return rpn_set_reg(ctx, i, arg, size, RPN_SET_REG_FLAG_RMFREE);
 }
@@ -1155,10 +1151,6 @@ static enum rpn_error rpn_op_ffirst(struct RedisModuleCtx *redis_ctx __unused, s
              * the original string was created.
              */
             s = RedisModule_CreateString(NULL, field_str, field_len);
-            if (!s) {
-                return RPN_ERR_ENOMEM;
-            }
-
             err = SelvaSet_Add(result->set, s);
             if (err) {
                 RedisModule_FreeString(NULL, s);
@@ -1508,10 +1500,6 @@ static enum rpn_error compile_selvaset_literal(struct rpn_expression *expr, size
             tok_len -= 2;
 
             RedisModuleString *rms = RedisModule_CreateString(NULL, tok_str, tok_len);
-            if (!rms) {
-                return RPN_ERR_ENOMEM;
-            }
-
             err = SelvaSet_Add(v->set, rms);
             if (err) {
                 RedisModule_FreeString(NULL, rms);
@@ -1546,17 +1534,10 @@ static enum rpn_error compile_operator(char *e, char c) {
 struct rpn_expression *rpn_compile(const char *input) {
     struct rpn_expression *expr;
     expr = RedisModule_Alloc(sizeof(struct rpn_expression));
-    if (!expr) {
-        return NULL;
-    }
     memset(expr->input_literal_reg, 0, sizeof(expr->input_literal_reg));
 
     size_t size = 2 * sizeof(rpn_token);
     expr->expression = RedisModule_Alloc(size);
-    if (!expr->expression) {
-        RedisModule_Free(expr);
-        return NULL;
-    }
 
     const char *delim = " \t\n\r\f";
     const char *group = "{\"";

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -918,6 +918,22 @@ static enum rpn_error rpn_op_rot(struct RedisModuleCtx *redis_crx __unused, stru
     return push(ctx, a);
 }
 
+static enum rpn_error rpn_op_over(struct RedisModuleCtx *redis_crx __unused, struct rpn_ctx *ctx) {
+    enum rpn_error err;
+    OPERAND(ctx, a);
+    OPERAND(ctx, b);
+
+    err = push(ctx, b);
+    if (err) {
+        return err;
+    }
+    err = push(ctx, a);
+    if (err) {
+        return err;
+    }
+    return push(ctx, b);
+}
+
 static enum rpn_error rpn_op_exists(struct RedisModuleCtx *redis_ctx __unused, struct rpn_ctx *ctx) {
     int exists;
     OPERAND(ctx, field);
@@ -1308,8 +1324,8 @@ static rpn_fp funcs[] = {
     rpn_op_swap,    /* S */
     rpn_op_ternary, /* T */
     rpn_op_drop,    /* U */
-    rpn_op_rot,     /* V */
-    rpn_op_abo,     /* W spare */
+    rpn_op_over,    /* V */
+    rpn_op_rot,     /* W */
     rpn_op_abo,     /* X */
     rpn_op_abo,     /* Y */
     rpn_op_abo,     /* Z */

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -521,7 +521,7 @@ enum rpn_error rpn_set_reg(struct rpn_ctx *ctx, size_t i, const char *s, size_t 
     return RPN_ERR_OK;
 }
 
-enum rpn_error rpn_set_reg_rm(struct rpn_ctx *ctx, size_t i, RedisModuleString *rms) {
+enum rpn_error rpn_set_reg_rms(struct rpn_ctx *ctx, size_t i, RedisModuleString *rms) {
     TO_STR(rms);
     const size_t size = rms_len + 1;
     char *arg;

--- a/server/modules/selva/module/subscriptions.c
+++ b/server/modules/selva/module/subscriptions.c
@@ -803,7 +803,7 @@ int Selva_AddSubscriptionAliasMarker(
      * Set RPN registers
      */
     enum rpn_error rpn_err;
-    if ((rpn_err = rpn_set_reg_rm(filter_ctx, 1, alias_name)) ||
+    if ((rpn_err = rpn_set_reg_rms(filter_ctx, 1, alias_name)) ||
         (rpn_err = rpn_set_reg(filter_ctx, 2, SELVA_ALIASES_FIELD, sizeof(SELVA_ALIASES_FIELD), 0))) {
         char str[SELVA_SUBSCRIPTION_ID_STR_LEN + 1];
 

--- a/server/modules/selva/test/redis-timer.c
+++ b/server/modules/selva/test/redis-timer.c
@@ -1,10 +1,10 @@
 #include "redismodule.h"
 
-RedisModuleTimerID _RedisModule_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisModuleTimerProc callback, void *data) {
+static RedisModuleTimerID _RedisModule_CreateTimer(RedisModuleCtx *ctx, mstime_t period, RedisModuleTimerProc callback, void *data) {
     return -1;
 }
 
-int _RedisModule_StopTimerUnsafe(RedisModuleTimerID id, void **data) {
+static int _RedisModule_StopTimerUnsafe(RedisModuleTimerID id, void **data) {
     return 0;
 }
 

--- a/server/modules/selva/test/units/Makefile
+++ b/server/modules/selva/test/units/Makefile
@@ -15,7 +15,7 @@ PU_UU := 1
 # test case descriptions. 0 = disabled; 1 = enabled.
 PU_REPORT_ORIENTED := 1
 
-CCFLAGS := $(CFLAGS) -Wextra -Wno-unused-value -Wno-unused-parameter -g -include ../tunables.h
+CCFLAGS := $(CFLAGS) -Wextra -Wno-unused-value -Wno-unused-parameter -Wno-implicit-function-declaration -g -include ../tunables.h
 
 # Location of punit makefile
 # Do not touch

--- a/server/modules/selva/test/units/test-rpn.c
+++ b/server/modules/selva/test/units/test-rpn.c
@@ -140,6 +140,23 @@ static char * test_add_double(void)
     return NULL;
 }
 
+static char * test_mul(void)
+{
+    enum rpn_error err;
+    long long res;
+    const char expr_str[] = "#2 #2 D";
+
+    expr = rpn_compile(expr_str);
+    pu_assert("expr is created", expr);
+
+    err = rpn_integer(NULL, ctx, expr, &res);
+
+    pu_assert_equal("No error", err, RPN_ERR_OK);
+    pu_assert_equal("2 * 2", res, 4);
+
+    return NULL;
+}
+
 static char * test_rem(void)
 {
     enum rpn_error err;
@@ -506,7 +523,7 @@ static char * test_selvaset_ill(void)
 
 static char * test_cond_jump(void)
 {
-    const char expr_str[][22] = {
+    static const char expr_str[][22] = {
         "#1 #1 A #1 >2 #1 A",
         "#1 #1 A #0 >2 #1 A",
         "#1 #1 A #1 >3 #1 A",
@@ -551,6 +568,40 @@ static char * test_cond_jump(void)
     return NULL;
 }
 
+static char * test_dup(void)
+{
+    enum rpn_error err;
+    long long res;
+    const char expr_str[] = "#2 R D";
+
+    expr = rpn_compile(expr_str);
+    pu_assert("expr is created", expr);
+
+    err = rpn_integer(NULL, ctx, expr, &res);
+
+    pu_assert_equal("No error", err, RPN_ERR_OK);
+    pu_assert_equal("2 * 2", res, 4);
+
+    return NULL;
+}
+
+static char * test_swap(void)
+{
+    enum rpn_error err;
+    long long res;
+    const char expr_str[] = "#4 #2 S C";
+
+    expr = rpn_compile(expr_str);
+    pu_assert("expr is created", expr);
+
+    err = rpn_integer(NULL, ctx, expr, &res);
+
+    pu_assert_equal("No error", err, RPN_ERR_OK);
+    pu_assert_equal("4 / 2", res, 2);
+
+    return NULL;
+}
+
 void all_tests(void)
 {
     pu_def_test(test_init_works, PU_RUN);
@@ -560,6 +611,7 @@ void all_tests(void)
     pu_def_test(test_stack_overflow, PU_RUN);
     pu_def_test(test_add, PU_RUN);
     pu_def_test(test_add_double, PU_RUN);
+    pu_def_test(test_mul, PU_RUN);
     pu_def_test(test_rem, PU_RUN);
     pu_def_test(test_range, PU_RUN);
     pu_def_test(test_necessarily_or, PU_RUN);
@@ -573,4 +625,6 @@ void all_tests(void)
     pu_def_test(test_selvaset_empty_2, PU_RUN);
     pu_def_test(test_selvaset_ill, PU_RUN);
     pu_def_test(test_cond_jump, PU_RUN);
+    pu_def_test(test_dup, PU_RUN);
+    pu_def_test(test_swap, PU_RUN);
 }

--- a/server/modules/selva/test/units/test-rpn.c
+++ b/server/modules/selva/test/units/test-rpn.c
@@ -360,6 +360,7 @@ static char * test_ternary(void)
 
         TO_STR(res);
         pu_assert_str_equal("Ternary result is valid", res_str, expected);
+        RedisModule_FreeString(NULL, res);
     }
 
     return NULL;

--- a/server/modules/selva/tunables.h
+++ b/server/modules/selva/tunables.h
@@ -82,7 +82,7 @@
  * Small operand pool size.
  * Small operands are pooled to speed up evaluating simple expressions.
  */
-#define RPN_SMALL_OPERAND_POOL_SIZE     40
+#define RPN_SMALL_OPERAND_POOL_SIZE     70
 
 /**
  * Max RPN stack depth.


### PR DESCRIPTION
The conditional jump operator `>` jumps over specified number of tokens that is
a compile time constant. The first an only argument popped from the stack is the
boolean condition that decides whether the operator will execute a jump.

The new duplicate (`R`), swap (`S`), drop (`U`), over `V`, and rotate (`W`)
operators supports conditional jump operators on more complex flows.

Now we also "compile" register references to a native unsigned type and
operators are translated into direct function pointers to improve execution
speed. This is probably as close as we can/should get to something like JIT
compilation.

On the client side this PR turns small string and numeric references into
inlined operands. The field name references are now deduplicated to
save register space.