### PR TITLE
RPN: Use labels with conditional jump

### DIFF
--- a/client/test/rpn.ts
+++ b/client/test/rpn.ts
@@ -70,7 +70,7 @@ test.serial('eval to double', async (t) => {
 
   // Test swap, duplicate, and forward jump
   // a > 5 ? 0 : a
-  const expr2 = '@1 R #5 S I >2 #0 D'
+  const expr2 = '@1 R #5 S I >2 #0 D .2:X'
   t.deepEqual(
     Number(await client.redis.selva_rpn_evaldouble('node123456', expr2, '3')),
     0
@@ -88,7 +88,7 @@ test.serial('eval to double', async (t) => {
 
   // drop, forward jump, and swap
   // a > 5 ? 0 : a
-  const expr3 = '@2 @1 R #5 H >1 S U'
+  const expr3 = '@2 @1 R #5 H >1 S .1:U'
   t.deepEqual(
     Number(await client.redis.selva_rpn_evaldouble('node123456', expr3, '3', '6')),
     3
@@ -126,7 +126,7 @@ test.serial('eval to string', async (t) => {
   )
 
   // a + 1 == 2 ? "true" : "false"
-  const expr1 = '@1 #1 A #2 F L >3 "true" #1 >1 "false"'
+  const expr1 = '@1 #1 A #2 F L >3 "true" #1 >1 .3:"false" .1:X'
   t.deepEqual(
     await client.redis.selva_rpn_evalstring('node123456', expr1, '1'),
     'true'

--- a/server/modules/selva/doc/hierarchy/expressions.md
+++ b/server/modules/selva/doc/hierarchy/expressions.md
@@ -152,10 +152,11 @@ Type codes used in the documentation:
 | `>`      | `(n) => <>`      | Conditional jump forward.               | `#1 >2 => <>`            |
 | `P`      | `(X) => n`       | Necessity `□a`. (It's necessary that a) | `#0 P #1 N => 0`         |
 | `Q`      | `(X) => n`       | Possibly `◇a`.                          | `#1 Q #0 M => 1`         |
+| `X`      | `(<>) => <>`     | No operation.                           | `#1 >1 .1:X`             |
 
 The conditional jump operator `>` jumps over specified number of tokens that is
-a compile time constant. The first an only argument popped from the stack is the
-boolean condition that decides whether the operator will execute a jump.
+a compile time constant. The first and only argument popped from the stack is
+the boolean condition that decides whether the operator will execute a jump.
 
 `P` and `Q` are short circuiting operators and don't represent classical modal
 logic. The `P` operator bails out immediately if the operand is not truthy and

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -1412,6 +1412,7 @@ static int parse_label(const char *tok_str, size_t tok_len) {
         return 0;
     }
 
+    memset(tmp, '\0', sizeof(tmp));
     for (size_t i = 1; i < min(tok_len, sizeof(tmp) - 1); i++) {
         int c = tok_str[i];
 

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -1463,9 +1463,10 @@ static size_t skip_label(const char **tok_str_p, size_t tok_len) {
 static int find_labels(int labels[RPN_MAX_LABELS], const char *input) {
     const char *delim = RPN_DELIM;
     const char *group = RPN_GROUP;
-    size_t i = 0;
     size_t tok_len = 0;
     const char *rest = NULL;
+    int i = 0;
+
     for (const char *tok_str = tokenize(input, delim, group, &rest, &tok_len);
          tok_str != NULL;
          tok_str = tokenize(NULL, delim, group, &rest, &tok_len)) {

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -1414,7 +1414,7 @@ static int parse_label(const char *tok_str, size_t tok_len) {
 
     memset(tmp, '\0', sizeof(tmp));
     for (size_t i = 1; i < min(tok_len, sizeof(tmp) - 1); i++) {
-        int c = tok_str[i];
+        char c = tok_str[i];
 
         if (isdigit(c)) {
             tmp[i - 1] = c;

--- a/server/modules/selva/module/rpn/rpn.c
+++ b/server/modules/selva/module/rpn/rpn.c
@@ -1256,6 +1256,10 @@ static enum rpn_error rpn_op_abo(struct RedisModuleCtx *redis_ctx __unused, stru
     return RPN_ERR_ILLOPC;
 }
 
+static enum rpn_error rpn_op_nop(struct RedisModuleCtx *redis_ctx __unused, struct rpn_ctx *ctx __unused) {
+    return RPN_ERR_OK;
+}
+
 typedef enum rpn_error (*rpn_fp)(struct RedisModuleCtx *redis_ctx, struct rpn_ctx *ctx);
 
 static rpn_fp funcs[] = {
@@ -1282,9 +1286,9 @@ static rpn_fp funcs[] = {
     rpn_op_drop,    /* U */
     rpn_op_over,    /* V */
     rpn_op_rot,     /* W */
-    rpn_op_abo,     /* X */
-    rpn_op_abo,     /* Y */
-    rpn_op_abo,     /* Z */
+    rpn_op_nop,     /* X */
+    rpn_op_abo,     /* Y spare */
+    rpn_op_abo,     /* Z spare */
     rpn_op_abo,     /* N/A */
     rpn_op_abo,     /* N/A */
     rpn_op_abo,     /* N/A */
@@ -1318,6 +1322,10 @@ static rpn_fp funcs[] = {
     rpn_op_abo,     /* y spare */
     rpn_op_union,   /* z spare */
 };
+
+#define RPN_DELIM " \t\n\r\f"
+#define RPN_GROUP "{\""
+#define RPN_MAX_LABELS 10 /* TODO Tunable */
 
 static const char *tokenize(const char *s, const char *delim, const char *group, const char **rest, size_t *len) {
     const char *spanp;
@@ -1388,7 +1396,97 @@ cont:
     } while (1);
 }
 
-static enum rpn_error compile_push_literal(struct rpn_expression *expr, size_t i, struct rpn_operand *v) {
+/**
+ * Parse a potential label.
+ * .<number>:
+ * .1:
+ * @returns 0 if no label was found;
+ *          -1 if the label was invald;
+ *          Otherwise the label number is returned.
+ */
+static int parse_label(const char *tok_str, size_t tok_len) {
+    char tmp[11];
+    int valid = 0;
+
+    if (tok_len < 3 || tok_str[0] != '.') {
+        return 0;
+    }
+
+    for (size_t i = 1; i < min(tok_len, sizeof(tmp) - 1); i++) {
+        int c = tok_str[i];
+
+        if (isdigit(c)) {
+            tmp[i - 1] = c;
+        } else if (c == ':') {
+            valid = 1;
+            break;
+        } else {
+            return -1;
+        }
+    }
+
+    if (!valid) {
+        return -1;
+    }
+
+    tmp[sizeof(tmp) - 1] = '\0';
+    int l = fast_atou(tmp);
+
+    if (l == 0 || l >= RPN_MAX_LABELS) {
+        return -1;
+    }
+
+    return l;
+}
+
+/**
+ * Return a pointer past the label.
+ */
+static size_t skip_label(const char **tok_str_p, size_t tok_len) {
+    const char *tok_str = *tok_str_p;
+
+    if (parse_label(tok_str, tok_len) <= 0) {
+        return tok_len;
+    }
+
+    const char *code_begin = strchr(tok_str, ':') + 1;
+    ssize_t label_len = (ssize_t)(code_begin - tok_str);
+
+    *tok_str_p = code_begin;
+    return (size_t)(max((ssize_t)tok_len - label_len, 0l));
+}
+
+/**
+ * Find and map all labels in the input expression.
+ */
+static int find_labels(int labels[RPN_MAX_LABELS], const char *input) {
+    const char *delim = RPN_DELIM;
+    const char *group = RPN_GROUP;
+    size_t i = 0;
+    size_t tok_len = 0;
+    const char *rest = NULL;
+    for (const char *tok_str = tokenize(input, delim, group, &rest, &tok_len);
+         tok_str != NULL;
+         tok_str = tokenize(NULL, delim, group, &rest, &tok_len)) {
+        int l = parse_label(tok_str, tok_len);
+
+        if (l > 0) {
+            if (labels[l] != 0) {
+                /* Disallow using the same label twice. */
+                return RPN_ERR_BADSTK;
+            }
+            labels[l] = i;
+        } else if (l == -1) {
+            /* Invalid label. */
+            return RPN_ERR_ILLOPN;
+        }
+        i++;
+    }
+
+    return RPN_ERR_OK;
+}
+
+static enum rpn_error compile_store_literal(struct rpn_expression *expr, size_t i, struct rpn_operand *v) {
     if (i >= RPN_MAX_D - 1) {
         return RPN_ERR_BADSTK;
     }
@@ -1420,7 +1518,7 @@ static enum rpn_error compile_num_literal(struct rpn_expression *expr, size_t i,
     v->s_size = 0;
     v->s[0] = '\0';
 
-    return compile_push_literal(expr, i, v);
+    return compile_store_literal(expr, i, v);
 }
 
 static enum rpn_error compile_str_literal(struct rpn_expression *expr, size_t i, const char *str, size_t len) {
@@ -1433,7 +1531,7 @@ static enum rpn_error compile_str_literal(struct rpn_expression *expr, size_t i,
     v->s[len] = '\0';
     v->d = nan("");
 
-    return compile_push_literal(expr, i, v);
+    return compile_store_literal(expr, i, v);
 }
 
 static enum rpn_error compile_selvaset_literal(struct rpn_expression *expr, size_t i, const char *str, size_t len) {
@@ -1485,7 +1583,7 @@ static enum rpn_error compile_selvaset_literal(struct rpn_expression *expr, size
         }
     }
 
-    return compile_push_literal(expr, i, v);
+    return compile_store_literal(expr, i, v);
 }
 
 /**
@@ -1511,14 +1609,21 @@ static enum rpn_error compile_operator(char *e, char c) {
 
 struct rpn_expression *rpn_compile(const char *input) {
     struct rpn_expression *expr;
+    size_t size = 2 * sizeof(rpn_token);
+
     expr = RedisModule_Alloc(sizeof(struct rpn_expression));
     memset(expr->input_literal_reg, 0, sizeof(expr->input_literal_reg));
-
-    size_t size = 2 * sizeof(rpn_token);
     expr->expression = RedisModule_Alloc(size);
 
-    const char *delim = " \t\n\r\f";
-    const char *group = "{\"";
+    int labels[RPN_MAX_LABELS] = { 0 };
+    if (find_labels(labels, input)) {
+        fprintf(stderr, "%s:%d:%s: Failed to parse labels\n",
+                __FILE__, __LINE__, __func__);
+        goto fail;
+    }
+
+    const char *delim = RPN_DELIM;
+    const char *group = RPN_GROUP;
     uint32_t input_literal_reg_i = 0;
     size_t i = 0;
     size_t tok_len = 0;
@@ -1529,6 +1634,11 @@ struct rpn_expression *rpn_compile(const char *input) {
         enum rpn_error err;
         char *e = expr->expression[i++];
         rpn_token *new;
+
+        /*
+         * Check if there is a label and skip it.
+         */
+        tok_len = skip_label(&tok_str, tok_len);
 
         if (tok_len == 0) {
             fprintf(stderr, "%s:%d:%s: Token length can't be zero\n",
@@ -1561,15 +1671,30 @@ struct rpn_expression *rpn_compile(const char *input) {
                         __FILE__, __LINE__, __func__);
                 goto fail;
             } else {
-                unsigned n = fast_atou(tok_str + 1);
+                unsigned l = fast_atou(tok_str + 1);
+                int n;
 
-                if (n > 255) {
-                    fprintf(stderr, "%s:%d:%s: Conditional jump too long\n",
+                if (l >= RPN_MAX_LABELS) {
+                    fprintf(stderr, "%s:%d:%s: Invalid label\n",
                             __FILE__, __LINE__, __func__);
                     goto fail;
                 }
 
-                compile_emit_code_uint32(e, RPN_CODE_JMP_FWD, n);
+                n = labels[l];
+                if (n == 0) {
+                    fprintf(stderr, "%s:%d:%s: Label not found: %d\n",
+                            __FILE__, __LINE__, __func__,
+                            n);
+                    goto fail;
+                }
+                if (n <= (int)i - 1) {
+                    fprintf(stderr, "%s:%d:%s: Can't jump backwards to %d with `>`\n",
+                            __FILE__, __LINE__, __func__,
+                            n);
+                    goto fail;
+                }
+
+                compile_emit_code_uint32(e, RPN_CODE_JMP_FWD, n - i);
             }
             goto next;
         default:

--- a/server/modules/selva/test/units/test-rpn.c
+++ b/server/modules/selva/test/units/test-rpn.c
@@ -513,35 +513,41 @@ static char * test_selvaset_ill(void)
     const char expr_str4[] = "{abc\",\"def\",\"verylongtextisalsoprettynice\",\"this is another one that is fairly long and with spaces\", \"nice\"}";
     const char expr_str5[] = "{abc\",\"def\",\"verylongtextisalsoprettynice\",\"this is another one that is fairly long and with spaces\", \"nice\",}";
 
-    pu_assert_equal("Fails", NULL,  rpn_compile(expr_str1));
-    pu_assert_equal("Fails", NULL,  rpn_compile(expr_str2));
-    pu_assert_equal("Fails", NULL,  rpn_compile(expr_str3));
-    pu_assert_equal("Fails", NULL,  rpn_compile(expr_str4));
-    pu_assert_equal("Fails", NULL,  rpn_compile(expr_str5));
+    pu_assert_equal("Fails", NULL, rpn_compile(expr_str1));
+    pu_assert_equal("Fails", NULL, rpn_compile(expr_str2));
+    pu_assert_equal("Fails", NULL, rpn_compile(expr_str3));
+    pu_assert_equal("Fails", NULL, rpn_compile(expr_str4));
+    pu_assert_equal("Fails", NULL, rpn_compile(expr_str5));
 
     return NULL;
 }
 
 static char * test_cond_jump(void)
 {
-    static const char expr_str[][22] = {
-        "#1 #1 A #1 >2 #1 A",
-        "#1 #1 A #0 >2 #1 A",
-        "#1 #1 A #1 >3 #1 A",
-        "#1 #1 A #1 >-3 #1 A",
-        "#1 #1 A #1 >30 #1 A",
-        "#1 #1 A #1 >9000 #1 A",
+    static const char expr_str[][30] = {
+        "#1 #1 A #1 >1  #1 A .1:X",
+        "#1 #1 A #0 >1  #1 A .1:X",
+        "#1 #1 A #1 >0  #1 A .1:X",
+        "#1 #1 A #1 >3  #1 A .1:X",
+        "#1 #1 A #1 >-3 #1 A .1:X",
+        "#1 R >1 .1:X",
+        "#1 R >1 X .1:X",
+        "#1 R >1 X .1:R >2 .2:X",
+        "#1 R >1 X .1:R >1 .1:X",
     };
     int expected[] = {
         2,
         3,
-        2, /* Too long jumps will just terminate early. */
+        -1, /* Invalid label. */
+        -1, /* Invalid label. */
         -1, /* Negative numbers should fail to compile. */
-        2, /* Too long jumps will just terminate early. */
-        -1, /* Jumps longer than 255 are not supported. */
+        1,
+        1,
+        1,
+        -1, /* Label reuse. */
     };
 
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < num_elem(expected); i++) {
         long long res;
         enum rpn_error err;
 


### PR DESCRIPTION
Using labels makes constructing expressions easier. However,
it's not problem free as concatenating unknown RPN expressions
could introduce label collisions.