### PR TITLE
SVector_Init() can no longer fail, cleanup

### DIFF
--- a/server/modules/selva/include/traversal_order.h
+++ b/server/modules/selva/include/traversal_order.h
@@ -70,7 +70,7 @@ int SelvaTraversal_ParseOrderArg(
  * @param order is the order requested.
  * @param limit is the expected length for the final SVector. Generally this can be the same as limit size of the response. 0 = auto.
  */
-int SelvaTraversalOrder_InitOrderResult(SVector *order_result, enum SelvaResultOrder order, ssize_t limit);
+void SelvaTraversalOrder_InitOrderResult(SVector *order_result, enum SelvaResultOrder order, ssize_t limit);
 
 /**
  * Destroy an order_result SVector and free its items properly.

--- a/server/modules/selva/lib/util/svector.c
+++ b/server/modules/selva/lib/util/svector.c
@@ -38,11 +38,7 @@ static int svector_rbtree_compar_wrap(struct SVector_rbnode *a, struct SVector_r
 
 RB_GENERATE_STATIC(SVector_rbtree, SVector_rbnode, entry, svector_rbtree_compar_wrap)
 
-SVector *SVector_Init(SVector *vec, size_t initial_len, int (*compar)(const void **a, const void **b)) {
-    if (unlikely(!vec)) {
-        return NULL;
-    }
-
+void SVector_Init(SVector *vec, size_t initial_len, int (*compar)(const void **a, const void **b)) {
     *vec = (SVector){
         .vec_mode = SVECTOR_MODE_ARRAY,
         .vec_compar = compar,
@@ -62,8 +58,6 @@ SVector *SVector_Init(SVector *vec, size_t initial_len, int (*compar)(const void
             mempool_init(&vec->vec_rbmempool, SVECTOR_SLAB_SIZE, sizeof(struct SVector_rbnode), alignof(struct SVector_rbnode));
         }
     }
-
-    return vec;
 }
 
 void SVector_Destroy(SVector *vec) {
@@ -145,10 +139,11 @@ SVector *SVector_Clone(SVector *dest, const SVector *src, int (*compar)(const vo
 
     assert(src->vec_arr_shift_index == 0);
 
-    if ((mode != SVECTOR_MODE_ARRAY && mode != SVECTOR_MODE_RBTREE) ||
-        !SVector_Init(dest, SVector_Size(src), compar)) {
+    if (mode != SVECTOR_MODE_ARRAY && mode != SVECTOR_MODE_RBTREE) {
         return NULL;
     }
+
+    SVector_Init(dest, SVector_Size(src), compar);
 
     /* Support lazy alloc. */
     if (unlikely(!src->vec_arr)) {

--- a/server/modules/selva/lib/util/svector.h
+++ b/server/modules/selva/lib/util/svector.h
@@ -80,7 +80,7 @@ static inline int SVector_IsInitialized(const SVector *vec) {
     return vec->vec_mode != SVECTOR_MODE_NONE;
 }
 
-SVector *SVector_Init(SVector *vec, size_t initial_len, int (*compar)(const void **a, const void **b));
+void SVector_Init(SVector *vec, size_t initial_len, int (*compar)(const void **a, const void **b));
 void SVector_Destroy(SVector *vec);
 SVector *SVector_Clone(SVector *dest, const SVector *src, int (*compar)(const void **a, const void **b));
 void SVector_Insert(SVector *vec, void *el);

--- a/server/modules/selva/module/aggregate.c
+++ b/server/modules/selva/module/aggregate.c
@@ -668,11 +668,7 @@ int SelvaHierarchy_AggregateCommand(RedisModuleCtx *ctx, RedisModuleString **arg
     TO_STR(ids);
 
     if (order != SELVA_RESULT_ORDER_NONE) {
-        err = SelvaTraversalOrder_InitOrderResult(&order_result, order, limit);
-        if (err) {
-            replyWithSelvaError(ctx, err);
-            goto out;
-        }
+        SelvaTraversalOrder_InitOrderResult(&order_result, order, limit);
     }
 
     /*
@@ -1043,11 +1039,7 @@ int SelvaHierarchy_AggregateInCommand(RedisModuleCtx *ctx, RedisModuleString **a
     TO_STR(ids);
 
     if (order != SELVA_RESULT_ORDER_NONE) {
-        err = SelvaTraversalOrder_InitOrderResult(&order_result, order, limit);
-        if (err) {
-            replyWithSelvaError(ctx, err);
-            goto out;
-        }
+        SelvaTraversalOrder_InitOrderResult(&order_result, order, limit);
     }
 
     /*

--- a/server/modules/selva/module/find.c
+++ b/server/modules/selva/module/find.c
@@ -1653,10 +1653,7 @@ static int SelvaHierarchy_FindCommand(RedisModuleCtx *ctx, RedisModuleString **a
     TO_STR(ids);
 
     if (order != SELVA_RESULT_ORDER_NONE) {
-        err = SelvaTraversalOrder_InitOrderResult(&order_result, order, limit);
-        if (err) {
-            return replyWithSelvaError(ctx, err);
-        }
+        SelvaTraversalOrder_InitOrderResult(&order_result, order, limit);
     }
 
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
@@ -2008,11 +2005,7 @@ int SelvaHierarchy_FindInCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
 
     SVECTOR_AUTOFREE(order_result); /*!< for ordered result. */
     if (order != SELVA_RESULT_ORDER_NONE) {
-        err = SelvaTraversalOrder_InitOrderResult(&order_result, order, limit);
-        if (err) {
-            replyWithSelvaError(ctx, err);
-            goto out;
-        }
+        SelvaTraversalOrder_InitOrderResult(&order_result, order, limit);
     }
 
     ssize_t array_len = 0;
@@ -2065,7 +2058,6 @@ int SelvaHierarchy_FindInCommand(RedisModuleCtx *ctx, RedisModuleString **argv, 
 
     RedisModule_ReplySetArrayLength(ctx, array_len);
 
-out:
     rpn_destroy(rpn_ctx);
 #if MEM_DEBUG
     memset(filter_expression, 0, sizeof(*filter_expression));

--- a/server/modules/selva/module/find_index/find_index.c
+++ b/server/modules/selva/module/find_index/find_index.c
@@ -81,19 +81,14 @@ static int skip_node(const struct SelvaFindIndexControlBlock *icb, const struct 
     return SelvaTraversal_GetSkip(icb->traversal.dir) && !memcmp(node_id, icb->traversal.node_id, SELVA_NODE_ID_SIZE);
 }
 
-static int icb_res_init(struct SelvaFindIndexControlBlock *icb) {
-    int err;
-
+static void icb_res_init(struct SelvaFindIndexControlBlock *icb) {
     if (icb->flags.ordered) {
         const size_t initial_len = (size_t)icb->find_acc.take_max_ave;
 
-        err = SelvaTraversalOrder_InitOrderResult(&icb->res.ord, icb->sort.order, initial_len);
+        SelvaTraversalOrder_InitOrderResult(&icb->res.ord, icb->sort.order, initial_len);
     } else {
         SelvaSet_Init(&icb->res.set, SELVA_SET_TYPE_NODEID);
-        err = 0;
     }
-
-    return err;
 }
 
 static void icb_clear_acc(struct SelvaFindIndexControlBlock *icb) {

--- a/server/modules/selva/module/hierarchy/traversal_order.c
+++ b/server/modules/selva/module/hierarchy/traversal_order.c
@@ -130,10 +130,10 @@ static orderFunc order_functions[] = {
 
 GENERATE_STATIC_FUNMAP(SelvaTraversal_GetOrderFunc, order_functions, enum SelvaResultOrder, SELVA_RESULT_ORDER_NONE);
 
-int SelvaTraversalOrder_InitOrderResult(SVector *order_result, enum SelvaResultOrder order, ssize_t limit) {
+void SelvaTraversalOrder_InitOrderResult(SVector *order_result, enum SelvaResultOrder order, ssize_t limit) {
     const size_t initial_len = (limit > 0) ? limit : HIERARCHY_EXPECTED_RESP_LEN;
 
-    return SVector_Init(order_result, initial_len, SelvaTraversal_GetOrderFunc(order)) ? 0 : SELVA_ENOMEM;
+    SVector_Init(order_result, initial_len, SelvaTraversal_GetOrderFunc(order));
 }
 
 void SelvaTraversalOrder_DestroyOrderResult(RedisModuleCtx *ctx, SVector *order_result) {

--- a/server/modules/selva/module/modify.c
+++ b/server/modules/selva/module/modify.c
@@ -169,9 +169,7 @@ static int update_edge(
         SVECTOR_AUTOFREE(new_ids);
 
         /* The comparator works for both nodes and nodeIds. */
-        if (!SVector_Init(&new_ids, setOpts->$value_len / SELVA_NODE_ID_SIZE, SelvaSVectorComparator_Node)) {
-            return SELVA_ENOMEM;
-        }
+        SVector_Init(&new_ids, setOpts->$value_len / SELVA_NODE_ID_SIZE, SelvaSVectorComparator_Node);
 
         for (size_t i = 0; i < setOpts->$value_len; i += SELVA_NODE_ID_SIZE) {
             char *dst_node_id = setOpts->$value + i;

--- a/server/modules/selva/module/selva_object/selva_object.c
+++ b/server/modules/selva/module/selva_object/selva_object.c
@@ -180,22 +180,11 @@ retry:
  * Init an array on key.
  * The key must be cleared before calling this function.
  */
-static int init_object_array(struct SelvaObjectKey *key, enum SelvaObjectType subtype, size_t size) {
-    key->type = SELVA_OBJECT_NULL;
-    key->subtype = SELVA_OBJECT_NULL;
-
-    key->array = RedisModule_Calloc(1, sizeof(SVector));
-
-    if (!SVector_Init(key->array, size, NULL)) {
-        RedisModule_Free(key->array);
-        key->array = NULL;
-        return SELVA_ENOMEM;
-    }
-
+static void init_object_array(struct SelvaObjectKey *key, enum SelvaObjectType subtype, size_t size) {
     key->type = SELVA_OBJECT_ARRAY;
     key->subtype = subtype;
-
-    return 0;
+    key->array = RedisModule_Calloc(1, sizeof(SVector));
+    SVector_Init(key->array, size, NULL);
 }
 
 static void clear_object_array(enum SelvaObjectType subtype, SVector *array) {
@@ -541,11 +530,7 @@ static int get_key_obj(struct SelvaObject *obj, const char *key_name_str, size_t
                 clear_key_value(key);
             }
 
-            err = init_object_array(key, SELVA_OBJECT_OBJECT, ary_idx + 1);
-            if (err) {
-                return err;
-            }
-
+            init_object_array(key, SELVA_OBJECT_OBJECT, ary_idx + 1);
             err = _insert_new_obj_into_array(obj, s, slen, ary_idx, &obj);
             if (err) {
                 return err;
@@ -1416,10 +1401,7 @@ int SelvaObject_AddArrayStr(struct SelvaObject *obj, const char *key_name_str, s
             return err;
         }
 
-        err = init_object_array(key, subtype, 1);
-        if (err) {
-            return err;
-        }
+        init_object_array(key, subtype, 1);
     }
 
     SVector_Insert(key->array, p);
@@ -1450,10 +1432,7 @@ int SelvaObject_InsertArrayStr(struct SelvaObject *obj, const char *key_name_str
             return err;
         }
 
-        err = init_object_array(key, subtype, 1);
-        if (err) {
-            return err;
-        }
+        init_object_array(key, subtype, 1);
     }
 
     SVector_Insert(key->array, p);
@@ -1484,10 +1463,7 @@ int SelvaObject_AssignArrayIndexStr(struct SelvaObject *obj, const char *key_nam
             return err;
         }
 
-        err = init_object_array(key, subtype, idx + 1);
-        if (err) {
-            return err;
-        }
+        init_object_array(key, subtype, idx + 1);
     }
 
     SVector_SetIndex(key->array, idx, p);
@@ -1517,10 +1493,7 @@ int SelvaObject_InsertArrayIndexStr(struct SelvaObject *obj, const char *key_nam
             return err;
         }
 
-        err = init_object_array(key, subtype, idx + 1);
-        if (err) {
-            return err;
-        }
+        init_object_array(key, subtype, idx + 1);
     }
 
     SVector_InsertIndex(key->array, idx, p);


### PR DESCRIPTION
- As SVector_Init() can no longer fail, we can remove a lot of
  error handling code that is ~~almost~~ never executed.