### PR TITLE
Don't make root subscriptions detached

### DIFF
--- a/server/modules/selva/module/subscriptions.c
+++ b/server/modules/selva/module/subscriptions.c
@@ -1218,13 +1218,10 @@ void SelvaSubscriptions_InheritParent(
         struct SVectorIterator it;
         struct Selva_SubscriptionMarker *marker;
         struct Selva_SubscriptionMarkers *node_sub_markers = &node_metadata->sub_markers;
+        const SVector *markers_vec;
 
         SelvaHierarchy_GetNodeId(parent_id, parent);
-
-        /*
-         * Note that normally root markers are detached and don't need to be inherited.
-         */
-        const SVector *markers_vec = &SelvaHierarchy_GetNodeMetadataByPtr(parent)->sub_markers.vec;
+        markers_vec = &SelvaHierarchy_GetNodeMetadataByPtr(parent)->sub_markers.vec;
 
         SVector_ForeachBegin(&it, markers_vec);
         while ((marker = SVector_Foreach(&it))) {
@@ -1276,9 +1273,6 @@ void SelvaSubscriptions_InheritChild(
         struct Selva_SubscriptionMarker *marker;
         struct Selva_SubscriptionMarkers *node_sub_markers;
 
-        /*
-         * Note that normally root markers are detached and don't need to be inherited.
-         */
         node_sub_markers = &node_metadata->sub_markers;
         SelvaHierarchy_GetNodeId(child_id, child);
 
@@ -2016,13 +2010,7 @@ int SelvaSubscriptions_AddMarkerCommand(RedisModuleCtx *ctx, RedisModuleString *
 
     unsigned short marker_flags = 0;
 
-    if (!memcmp(node_id, ROOT_NODE_ID, SELVA_NODE_ID_SIZE)) {
-        /*
-         * A root node marker is a special case which is stored as detached to
-         * save time and space.
-         */
-        marker_flags = SELVA_SUBSCRIPTION_FLAG_DETACH;
-    } else if (sub_dir & (SELVA_HIERARCHY_TRAVERSAL_CHILDREN | SELVA_HIERARCHY_TRAVERSAL_PARENTS)) {
+    if (sub_dir & (SELVA_HIERARCHY_TRAVERSAL_CHILDREN | SELVA_HIERARCHY_TRAVERSAL_PARENTS)) {
         /*
          * RFE We might want to have an arg for REF flag
          * but currently it seems to be enough to support

--- a/server/modules/selva/module/subscriptions.c
+++ b/server/modules/selva/module/subscriptions.c
@@ -325,9 +325,11 @@ static void do_sub_marker_removal(RedisModuleCtx *ctx, SelvaHierarchy *hierarchy
          */
         if (ctx) {
             clear_node_sub(ctx, hierarchy, marker, marker->node_id);
+#if 0
         } else {
             fprintf(stderr, "%s:%d: Warning no RedisModuleCtx given. This usually means that the whole hierarchy key will be deleted.\n",
                     __FILE__, __LINE__);
+#endif
         }
     }
     destroy_marker(marker);


### PR DESCRIPTION
The assumption was that we could optimize subscription markers
starting from the root node by marking them as detached as
everything is a descendant of the root node anyway. However,
this is less simple with edge fields and detached hierarchies.
Moreover, making these markers detached complicates triggering
some events like deletes.