### PR TITLE
Remove 'uc' flags on modify

### DIFF
--- a/client/src/set/validate.ts
+++ b/client/src/set/validate.ts
@@ -87,13 +87,6 @@ export default async function parseSetObject(
 
   const fields = schema.fields
 
-  if (!payload.updatedAt && fields.updatedAt?.type === 'timestamp') {
-    result[0] += 'u'
-  }
-  if (!payload.createdAt && fields.createdAt?.type === 'timestamp') {
-    result[0] += 'c'
-  }
-
   for (const key in payload) {
     if (key === 'type') {
       // Drop


### PR DESCRIPTION
`updatedAt` and `createdAt` fields are now always present
internally and the old flags are unnecessary.