### PR TITLE
Hide selva.modify from Redis logs

### DIFF
--- a/server/modules/selva/module/modify.c
+++ b/server/modules/selva/module/modify.c
@@ -1895,7 +1895,7 @@ static int Modify_OnLoad(RedisModuleCtx *ctx) {
     /*
      * Register commands.
      */
-    if (RedisModule_CreateCommand(ctx, "selva.modify", SelvaCommand_Modify, "write deny-oom", 1, 1, 1) == REDISMODULE_ERR) {
+    if (RedisModule_CreateCommand(ctx, "selva.modify", SelvaCommand_Modify, "write deny-oom no-monitor no-slowlog", 1, 1, 1) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 


### PR DESCRIPTION
The command uses binary buffers that breaks terminals when
printed to stdout.