### PR TITLE
Use mempool for hierarchy nodes

### DIFF
--- a/server/modules/selva/include/hierarchy.h
+++ b/server/modules/selva/include/hierarchy.h
@@ -6,6 +6,7 @@
 #include "linker_set.h"
 #include "selva.h"
 #include "svector.h"
+#include "mempool.h"
 #include "tree.h"
 #include "trx.h"
 #include "edge.h"
@@ -78,6 +79,7 @@ struct SelvaHierarchy {
      * Index of all hierarchy nodes by ID.
      */
     struct hierarchy_index_tree index_head;
+    struct mempool node_pool;
 
     /**
      * Orphan nodes aka heads of the hierarchy.

--- a/server/modules/selva/module/hierarchy/hierarchy.c
+++ b/server/modules/selva/module/hierarchy/hierarchy.c
@@ -215,6 +215,7 @@ RB_GENERATE_STATIC(hierarchy_index_tree, SelvaHierarchyNode, _index_entry, Selva
 SelvaHierarchy *SelvaModify_NewHierarchy(RedisModuleCtx *ctx) {
     SelvaHierarchy *hierarchy = RedisModule_Calloc(1, sizeof(*hierarchy));
 
+    mempool_init(&hierarchy->node_pool, 33554432, sizeof(SelvaHierarchyNode), _Alignof(SelvaHierarchyNode));
     RB_INIT(&hierarchy->index_head);
     SVector_Init(&hierarchy->heads, 1, SVector_HierarchyNode_id_compare);
     SelvaObject_Init(hierarchy->types._obj_data);
@@ -273,6 +274,7 @@ void SelvaModify_DestroyHierarchy(SelvaHierarchy *hierarchy) {
         (void)RedisModule_StopTimerUnsafe(hierarchy->inactive.auto_compress_timer, NULL);
     }
     SelvaHierarchy_DeinitInactiveNodes(hierarchy);
+    mempool_destroy(&hierarchy->node_pool);
 
 #if MEM_DEBUG
     memset(hierarchy, 0, sizeof(*hierarchy));
@@ -371,7 +373,7 @@ static int create_node_object(struct SelvaHierarchy *hierarchy, SelvaHierarchyNo
  * Create a new node.
  */
 static SelvaHierarchyNode *newNode(RedisModuleCtx *ctx, struct SelvaHierarchy *hierarchy, const Selva_NodeId id) {
-    SelvaHierarchyNode *node = RedisModule_Calloc(1, sizeof(SelvaHierarchyNode));
+    SelvaHierarchyNode *node = mempool_get(&hierarchy->node_pool);
 
 #if 0
     fprintf(stderr, "%s:%d: Creating node %.*s\n",
@@ -440,7 +442,7 @@ static void SelvaModify_DestroyNode(RedisModuleCtx *ctx, SelvaHierarchy *hierarc
 #if MEM_DEBUG
     memset(node, 0, sizeof(*node));
 #endif
-    RedisModule_Free(node);
+    mempool_return(&hierarchy->node_pool, node);
 }
 
 /**


### PR DESCRIPTION
Using a memory pool helps to
- keep the nodes closer to each other in memory
- reduce memory fragmentation
- reduce allocation overhead

```
    base:       114368.51479387283
                116252.68732690811
    pool 4MB:   103637.90022087097
    pool 32MB:  105092.8202829361
```

32 MB is probably just slower because of some kernel overhead. 32 MB fits about 63550 nodes.