### PR TITLE
Never size limit the slave replication buffers

### DIFF
--- a/server/redis/0004-Never-size-limit-the-slave-replication-buffers.patch
+++ b/server/redis/0004-Never-size-limit-the-slave-replication-buffers.patch
@@ -1,0 +1,73 @@
+From a25f9089c8ce79111aebe0d865fd6a6844a93952 Mon Sep 17 00:00:00 2001
+From: Olli Vanhoja <olli.vanhoja@gmail.com>
+Date: Mon, 29 Aug 2022 14:44:23 +0200
+Subject: [PATCH] Never size limit the slave replication buffers
+
+The replica will crash if the connection is disconnected. In case
+of a replica we need to get the data moving anyway and therefore
+limiting how much we can replicate doesn't make sense.
+---
+ src/networking.c | 20 ++++++++++++++++----
+ 1 file changed, 16 insertions(+), 4 deletions(-)
+
+diff --git a/src/networking.c b/src/networking.c
+index dd2ca1aae..92da8e2ef 100644
+--- a/src/networking.c
++++ b/src/networking.c
+@@ -856,7 +856,7 @@ void AddReplyFromClient(client *dst, client *src) {
+     if (src->flags & CLIENT_CLOSE_ASAP) {
+         sds client = catClientInfoString(sdsempty(),dst);
+         freeClientAsync(dst);
+-        serverLog(LL_WARNING,"Client %s scheduled to be closed ASAP for overcoming of output buffer limits.", client);
++        serverLog(LL_WARNING,"%s(): Client %s scheduled to be closed ASAP for overcoming of output buffer limits.", __func__, client);
+         sdsfree(client);
+         return;
+     }
+@@ -2842,6 +2842,9 @@ int checkClientOutputBufferLimits(client *c) {
+      * like normal clients. */
+     if (class == CLIENT_TYPE_MASTER) class = CLIENT_TYPE_NORMAL;
+ 
++    /* Never drop slaves. */
++    if (class == CLIENT_TYPE_SLAVE) return 0;
++
+     if (server.client_obuf_limits[class].hard_limit_bytes &&
+         used_mem >= server.client_obuf_limits[class].hard_limit_bytes)
+         hard = 1;
+@@ -2868,7 +2871,7 @@ int checkClientOutputBufferLimits(client *c) {
+     } else {
+         c->obuf_soft_limit_reached_time = 0;
+     }
+-    return soft || hard;
++    return soft | hard << 1;
+ }
+ 
+ /* Asynchronously close a client if soft or hard limit is reached on the
+@@ -2879,14 +2882,23 @@ int checkClientOutputBufferLimits(client *c) {
+  * called from contexts where the client can't be freed safely, i.e. from the
+  * lower level functions pushing data inside the client output buffers. */
+ void asyncCloseClientOnOutputBufferLimitReached(client *c) {
++    int lim;
++
+     if (!c->conn) return; /* It is unsafe to free fake clients. */
+     serverAssert(c->reply_bytes < SIZE_MAX-(1024*64));
+     if (c->reply_bytes == 0 || c->flags & CLIENT_CLOSE_ASAP) return;
+-    if (checkClientOutputBufferLimits(c)) {
++
++    lim = checkClientOutputBufferLimits(c);
++    if (lim) {
++        int class = getClientType(c);
+         sds client = catClientInfoString(sdsempty(),c);
+ 
++        /* For the purpose of output buffer limiting, masters are handled
++         * like normal clients. */
++        if (class == CLIENT_TYPE_MASTER) class = CLIENT_TYPE_NORMAL;
++
+         freeClientAsync(c);
+-        serverLog(LL_WARNING,"Client %s scheduled to be closed ASAP for overcoming of output buffer limits.", client);
++        serverLog(LL_WARNING,"%s(): Client %s (class: %d) scheduled to be closed ASAP for overcoming of output buffer limits (soft: %d hard: %d).", __func__, client, class, lim & 1, !!(lim & 2));
+         sdsfree(client);
+     }
+ }
+-- 
+2.37.0
+

--- a/server/redis/Dockerfile
+++ b/server/redis/Dockerfile
@@ -9,6 +9,7 @@ RUN cd redis && \
     git apply /redis-patches/0001-Add-RM_ReplicateVerbatimArgs.patch && \
     git apply /redis-patches/0002-Add-ReplyWithBinaryBuffer-for-sending-bin-bufs.patch && \
     git apply /redis-patches/0003-Add-RedisModule_StopTimerUnsafe.patch && \
+    git apply /redis-patches/0004-Never-size-limit-the-slave-replication-buffers.patch && \
     make PROG_SUFFIX="-selva"
 
 CMD cp /redis/src/redis-server-selva /dist/redis-server-selva; echo "Done"


### PR DESCRIPTION
The replica will crash if the connection is disconnected. In case
of a replica we need to get the data moving anyway and therefore
limiting how much we can replicate doesn't make sense.