### PR TITLE
Fix $noRoot

### DIFF
--- a/client/src/set/fieldParsers/references.ts
+++ b/client/src/set/fieldParsers/references.ts
@@ -85,7 +85,6 @@ const toCArr = async (
   schema: Schema,
   result: any,
   setObj: ({ [index: string]: any } | string)[] | string | undefined | null,
-  noRoot: boolean,
   lang?: string
 ) => {
   if (!setObj) {
@@ -190,11 +189,8 @@ export default async (
   type: string,
   $lang?: string
 ): Promise<number> => {
-  let noRoot = field === 'parents'
   const r: SetOptions = {}
   const isEmpty = (v: any) => !v || !v.length
-
-  // TODO: fix noRoot
 
   if (
     typeof payload === 'object' &&
@@ -263,9 +259,6 @@ export default async (
 
         r.$noRoot = payload[k]
         hasKeys = true
-        if (field === 'parents') {
-          noRoot = payload[k]
-        }
       } else if (k === '$_itemCount') {
         // ignore this internal field if setting with a split payload
       } else {
@@ -289,7 +282,6 @@ export default async (
             schema,
             result,
             r.$add,
-            noRoot,
             $lang
           ),
           $delete: await toCArr(
@@ -299,7 +291,6 @@ export default async (
             schema,
             result,
             r.$delete,
-            noRoot,
             $lang
           ),
           $value: await toCArr(
@@ -309,7 +300,6 @@ export default async (
             schema,
             result,
             r.$value,
-            noRoot,
             $lang
           ),
         })
@@ -337,7 +327,6 @@ export default async (
       schema,
       result,
       r,
-      noRoot,
       $lang
     )
 

--- a/client/src/set/validate.ts
+++ b/client/src/set/validate.ts
@@ -64,7 +64,8 @@ export default async function parseSetObject(
   ;(<any>result).$extraQueries = []
 
   //  && (<any>payload.parents).$noRoot
-  if (payload.parents) {
+  const isNonEmpty = (v: any): boolean => !!(v && v.length)
+  if (payload.parents && (payload.parents['$noRoot'] || Array.isArray(payload.parents) || payload.parents.$value || isNonEmpty(payload.parents['$add']))) {
     result[0] += 'N'
   }
 

--- a/server/modules/selva/module/modify.c
+++ b/server/modules/selva/module/modify.c
@@ -1654,7 +1654,7 @@ int SelvaCommand_Modify(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             return REDISMODULE_OK;
         }
 
-        const size_t nr_parents = FISSET_NO_ROOT(flags) ? 0 : 1;
+        const size_t nr_parents = !FISSET_NO_ROOT(flags);
 
         err = SelvaModify_SetHierarchy(ctx, hierarchy, nodeId, nr_parents, ((Selva_NodeId []){ ROOT_NODE_ID }), 0, NULL, &node);
         if (err < 0) {


### PR DESCRIPTION
Currently `$noRoot` is not actually handled at all, despite all the
flags and booleans that are passed around. It has been just pure
luck that most tests have been passing.