### PR TITLE
Skip building jemalloc and locales

### DIFF
--- a/server/modules/Dockerfile
+++ b/server/modules/Dockerfile
@@ -14,7 +14,7 @@ COPY ./binaries/linux_x64 /data/binaries/linux_x64
 ENV LOCPATH="/data/locale.build"
 
 CMD \
-    cd /data/jemalloc && make -j4; cp /data/binaries/linux_x64/libjemalloc_selva* /dist/; \
+    #cd /data/jemalloc && make -j4; cp /data/binaries/linux_x64/libjemalloc_selva* /dist/; \
     cd /data/selva && make -j4 && cp ./module.so /dist/selva.so; \
-    cd /data/locale && make -j4; \
-    cd "$LOCPATH" && find "./" -type f -exec install -D "--group=$DOCKER_GROUP" "--owner=$DOCKER_USER" "{}" "/locale/{}" \;
+    #cd /data/locale && make -j4; \
+    #cd "$LOCPATH" && find "./" -type f -exec install -D "--group=$DOCKER_GROUP" "--owner=$DOCKER_USER" "{}" "/locale/{}" \;


### PR DESCRIPTION
We don't need to build these every time. Perhaps we should figure out a way to build them on changes or something.