### PR TITLE
Fix != filter when $language is set

### DIFF
--- a/client/test/findByType.ts
+++ b/client/test/findByType.ts
@@ -259,7 +259,6 @@ test.serial('find - by IS NOT type', async (t) => {
       },
     },
   })
-
   t.is(res.matches.length, 1)
 
   const resWithLanguage = await client.get({
@@ -278,8 +277,34 @@ test.serial('find - by IS NOT type', async (t) => {
       },
     },
   })
-
   t.is(resWithLanguage.matches.length, 1)
+
+  await client.set({
+    $id: 'ma2',
+    parents: ['le1'],
+    type: 'match',
+    name: 'match 2',
+    description: { en: 'some' },
+    value: 1,
+  })
+
+  const resWithLanguage1 = await client.get({
+    $language: 'en',
+    matches: {
+      id: true,
+      $list: {
+        $find: {
+          $traverse: 'descendants',
+          $filter: {
+            $field: 'description',
+            $operator: '!=',
+            $value: 'some',
+          },
+        },
+      },
+    },
+  })
+  t.is(resWithLanguage1.matches.length, 2)
 
   await client.delete('root')
   await client.destroy()

--- a/query-ast-parser/src/ast2rpn.ts
+++ b/query-ast-parser/src/ast2rpn.ts
@@ -97,7 +97,7 @@ export default function ast2rpn(
         types,
         {
           isFork: true,
-          $or: [
+          [f.$operator == '!=' ? '$and' : '$or']: [
             {
               $operator: f.$operator,
               $field: f.$field,


### PR DESCRIPTION
Fix != filter for type field when $language is set
If `$language` is set we always assume that any field containg
a string value might be a `text` field. This is problematic with
the `!=` operator in a filter because `field.lang` doesn't exist
for `string` fields.

For example:

```
$filter: {
  $field: 'type',
  $operator: '!=',
  $value: 'league',
}
```

currently becomes:

```
[ '$2 $1 f c L $4 $3 f c L N', 'type', 'league', 'type.en', 'league' ]
```

while it should either skip `.en` for non-text fields or change the
OR operator `N` to the AND operator `M` when `$operator` in the
`$filter` equals to `!=`.
