### PR TITLE
Make some scripts more portable

### DIFF
--- a/bin/debug_subs.sh
+++ b/bin/debug_subs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2022 SAULX
 # SPDX-License-Identifier: MIT
 

--- a/bin/transpileScript
+++ b/bin/transpileScript
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2022 SAULX
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
`/bin/bash` doesn't exist in some Linux distributions.