### PR TITLE
Better sub marker management

### DIFF
--- a/client/src/get/executeGetOperations/inherit.ts
+++ b/client/src/get/executeGetOperations/inherit.ts
@@ -106,21 +106,12 @@ async function mergeObj(
 
   if (ctx.subId) {
     bufferNodeMarker(ctx, op.id, ...fields)
-    const added = await addMarker(client, ctx, {
+    await addMarker(client, ctx, {
       type: 'ancestors',
       id: op.id,
       fields,
       rpn,
     })
-
-    if (added) {
-      client.redis.selva_subscriptions_refresh(
-        ctx.originDescriptors[ctx.db] || { name: ctx.db },
-        '___selva_hierarchy',
-        ctx.subId
-      )
-      ctx.hasFindMarkers = true
-    }
   }
 
   const res = await client.redis.selva_hierarchy_find(
@@ -206,7 +197,7 @@ async function deepMergeObj(
 
   if (ctx.subId) {
     bufferNodeMarker(ctx, op.id, ...fields)
-    const added = await addMarker(
+    await addMarker(
       client,
       ctx,
       {
@@ -217,15 +208,6 @@ async function deepMergeObj(
       },
       passedOnSchema
     )
-
-    if (added) {
-      client.redis.selva_subscriptions_refresh(
-        ctx.originDescriptors[ctx.db] || { name: ctx.db },
-        '___selva_hierarchy',
-        ctx.subId
-      )
-      ctx.hasFindMarkers = true
-    }
   }
 
   const res = await client.redis.selva_hierarchy_find(
@@ -308,7 +290,7 @@ async function inheritItem(
 
   if (ctx.subId) {
     bufferNodeMarker(ctx, op.id, ...fields)
-    const added = await addMarker(
+    await addMarker(
       client,
       ctx,
       {
@@ -319,15 +301,6 @@ async function inheritItem(
       },
       passedOnSchema
     )
-
-    if (added) {
-      client.redis.selva_subscriptions_refresh(
-        ctx.originDescriptors[ctx.db] || { name: ctx.db },
-        '___selva_hierarchy',
-        ctx.subId
-      )
-      ctx.hasFindMarkers = true
-    }
   }
 
   const [results] = await client.redis.selva_hierarchy_find(
@@ -426,7 +399,7 @@ export default async function inherit(
   if (fs && fs.type === 'reference') {
     if (ctx.subId) {
       bufferNodeMarker(ctx, op.id, op.sourceField)
-      const added = await addMarker(
+      await addMarker(
         client,
         ctx,
         {
@@ -459,15 +432,6 @@ export default async function inherit(
         },
         passedOnSchema
       )
-
-      if (added) {
-        client.redis.selva_subscriptions_refresh(
-          ctx.originDescriptors[ctx.db] || { name: ctx.db },
-          '___selva_hierarchy',
-          ctx.subId
-        )
-        ctx.hasFindMarkers = true
-      }
     }
 
     const res = await client.redis.selva_inherit(
@@ -514,7 +478,7 @@ export default async function inherit(
 
     if (ctx.subId) {
       bufferNodeMarker(ctx, op.id, op.sourceField)
-      const added = await addMarker(
+      await addMarker(
         client,
         ctx,
         {
@@ -547,15 +511,6 @@ export default async function inherit(
         },
         passedOnSchema
       )
-
-      if (added) {
-        client.redis.selva_subscriptions_refresh(
-          ctx.originDescriptors[ctx.db] || { name: ctx.db },
-          '___selva_hierarchy',
-          ctx.subId
-        )
-        ctx.hasFindMarkers = true
-      }
     }
 
     const res = await client.redis.selva_inherit(
@@ -654,7 +609,7 @@ export default async function inherit(
       )
     } else {
       bufferNodeMarker(ctx, op.id, ...fields)
-      added = await addMarker(
+      await addMarker(
         client,
         ctx,
         {
@@ -692,15 +647,6 @@ export default async function inherit(
         },
         passedOnSchema
       )
-    }
-
-    if (added) {
-      client.redis.selva_subscriptions_refresh(
-        ctx.originDescriptors[ctx.db] || { name: ctx.db },
-        '___selva_hierarchy',
-        ctx.subId
-      )
-      ctx.hasFindMarkers = true
     }
   }
 

--- a/client/src/get/index.ts
+++ b/client/src/get/index.ts
@@ -1,7 +1,11 @@
 import { SelvaClient } from '..'
 import { GetResult, GetOptions, ObserveEventOptions } from './types'
 import createGetOperations from './createGetOperations'
-import executeGetOperations, { adler32 } from './executeGetOperations'
+import executeGetOperations, {
+  adler32,
+  refreshMarkers,
+  addNodeMarkers,
+} from './executeGetOperations'
 import resolveId from './resolveId'
 import combineResults from './combineResults'
 import { createRpn } from '@saulx/selva-query-ast-parser'
@@ -198,6 +202,11 @@ async function get(
     ctx,
     createGetOperations(client, newProps, id, '', db)
   )
+
+  if (!nested) {
+    await addNodeMarkers(client, ctx)
+    await refreshMarkers(client, ctx)
+  }
 
   // maybe ncie function?
   if (meta || props.$includeMeta) {

--- a/client/src/get/index.ts
+++ b/client/src/get/index.ts
@@ -203,10 +203,8 @@ async function get(
     createGetOperations(client, newProps, id, '', db)
   )
 
-  if (!nested) {
-    await addNodeMarkers(client, ctx)
-    await refreshMarkers(client, ctx)
-  }
+  await addNodeMarkers(client, ctx)
+  await refreshMarkers(client, ctx)
 
   // maybe ncie function?
   if (meta || props.$includeMeta) {

--- a/client/src/get/index.ts
+++ b/client/src/get/index.ts
@@ -203,8 +203,12 @@ async function get(
     createGetOperations(client, newProps, id, '', db)
   )
 
-  await addNodeMarkers(client, ctx)
-  await refreshMarkers(client, ctx)
+  try {
+    await addNodeMarkers(client, ctx)
+    await refreshMarkers(client, ctx)
+  } catch (e) {
+    console.error(e)
+  }
 
   // maybe ncie function?
   if (meta || props.$includeMeta) {

--- a/client/test/subscriptionDbFind.ts
+++ b/client/test/subscriptionDbFind.ts
@@ -21,6 +21,8 @@ test.before(async (t) => {
     port: port2,
   })
 
+  await wait(1000)
+
   const client = connect({ port })
   await client.updateSchema({
     languages: ['en'],
@@ -83,8 +85,8 @@ test.after(async (t) => {
 test.serial('subscription find multi-db', async (t) => {
   const client = connect({ port })
 
-  const matches = []
-  const teams = []
+  const matches: any[] = []
+  const teams: any[] = []
 
   for (let i = 0; i < 100; i++) {
     teams.push({


### PR DESCRIPTION
Moves marker handling from `executeGetOperations()` loop to `get()` to guarantee we don't run `refresh()` too much.

Solves performance issues with `test/z21_youri_query.ts`, taking the execution time on my M2 from ~4s to ~600ms for the nested find subscription.

Also updated inherit logic to do less, and to use the external marker system.

==

Ran all the tests and seems there are no regressions compared to current state of the `master` branch.