### PR TITLE
Buffer find markers

### DIFF
--- a/client/src/get/executeGetOperations/aggregate.ts
+++ b/client/src/get/executeGetOperations/aggregate.ts
@@ -13,7 +13,7 @@ import {
   ExecContext,
   sourceFieldToDir,
   sourceFieldToFindArgs,
-  addMarker,
+  bufferFindMarker,
 } from './'
 import { padId, joinIds, NODE_ID_SIZE } from '../../util'
 import { getNestedSchema } from '../utils'
@@ -345,7 +345,7 @@ const executeAggregateOperation = async (
         const id = op.id.substr(i, endLen)
         const schema = client.schemas[ctx.db]
         const sourceFieldSchema = getNestedSchema(schema, id, sourceField)
-        const r = await addMarker(client, ctx, {
+        bufferFindMarker(ctx, {
           ...sourceFieldToDir(
             schema,
             sourceFieldSchema,
@@ -358,18 +358,12 @@ const executeAggregateOperation = async (
           rpn: args,
         })
 
-        added = added || r
-
         await checkForNextRefresh(ctx, client, sourceField, id, op.filter, lang)
-      }
-
-      if (added) {
-        ctx.hasFindMarkers = true
       }
     } else {
       const schema = client.schemas[ctx.db]
       const sourceFieldSchema = getNestedSchema(schema, op.id, sourceField)
-      const added = await addMarker(client, ctx, {
+      bufferFindMarker(ctx, {
         ...sourceFieldToDir(
           schema,
           sourceFieldSchema,
@@ -381,10 +375,6 @@ const executeAggregateOperation = async (
         fields: op.props.$all === true ? [] : Object.keys(realOpts),
         rpn: args,
       })
-
-      if (added) {
-        ctx.hasFindMarkers = true
-      }
     }
 
     const schema = client.schemas[ctx.db]

--- a/client/src/get/executeGetOperations/inherit.ts
+++ b/client/src/get/executeGetOperations/inherit.ts
@@ -12,8 +12,8 @@ import {
   typeCast,
   ExecContext,
   executeNestedGetOperations,
-  addMarker,
   bufferNodeMarker,
+  bufferFindMarker,
 } from './'
 import { Schema, FieldSchema } from '../../schema'
 import { ast2rpn } from '@saulx/selva-query-ast-parser'
@@ -106,7 +106,7 @@ async function mergeObj(
 
   if (ctx.subId) {
     bufferNodeMarker(ctx, op.id, ...fields)
-    await addMarker(client, ctx, {
+    bufferFindMarker(ctx, {
       type: 'ancestors',
       id: op.id,
       fields,
@@ -197,8 +197,7 @@ async function deepMergeObj(
 
   if (ctx.subId) {
     bufferNodeMarker(ctx, op.id, ...fields)
-    await addMarker(
-      client,
+    bufferFindMarker(
       ctx,
       {
         type: 'ancestors',
@@ -290,8 +289,7 @@ async function inheritItem(
 
   if (ctx.subId) {
     bufferNodeMarker(ctx, op.id, ...fields)
-    await addMarker(
-      client,
+    bufferFindMarker(
       ctx,
       {
         type: 'ancestors',
@@ -399,8 +397,7 @@ export default async function inherit(
   if (fs && fs.type === 'reference') {
     if (ctx.subId) {
       bufferNodeMarker(ctx, op.id, op.sourceField)
-      await addMarker(
-        client,
+      bufferFindMarker(
         ctx,
         {
           type: 'ancestors',
@@ -478,8 +475,7 @@ export default async function inherit(
 
     if (ctx.subId) {
       bufferNodeMarker(ctx, op.id, op.sourceField)
-      await addMarker(
-        client,
+      bufferFindMarker(
         ctx,
         {
           type: 'ancestors',
@@ -563,11 +559,9 @@ export default async function inherit(
   if (ctx.subId) {
     const sourceFieldSchema = getNestedSchema(schema, op.id, op.sourceField)
 
-    let added: boolean
     if (sourceFieldSchema && sourceFieldSchema.type === 'reference') {
       bufferNodeMarker(ctx, op.id, op.sourceField)
-      added = await addMarker(
-        client,
+      bufferFindMarker(
         ctx,
         {
           type: 'bfs_expression',
@@ -609,8 +603,7 @@ export default async function inherit(
       )
     } else {
       bufferNodeMarker(ctx, op.id, ...fields)
-      await addMarker(
-        client,
+      bufferFindMarker(
         ctx,
         {
           type: 'ancestors',

--- a/client/src/get/executeGetOperations/timeseries.ts
+++ b/client/src/get/executeGetOperations/timeseries.ts
@@ -6,12 +6,7 @@ import {
   getTypeFromId,
   setNestedResult,
 } from '../utils'
-import {
-  ExecContext,
-  addMarker,
-  executeGetOperation,
-  bufferNodeMarker,
-} from './'
+import { ExecContext, executeGetOperation, bufferNodeMarker } from './'
 import { TimeseriesContext } from '../../timeseries'
 import { CreatePartialDiff } from '@saulx/diff'
 import { readLongLong } from '../executeGetOperations'

--- a/client/src/get/index.ts
+++ b/client/src/get/index.ts
@@ -5,6 +5,7 @@ import executeGetOperations, {
   adler32,
   refreshMarkers,
   addNodeMarkers,
+  flushFindMarkers,
 } from './executeGetOperations'
 import resolveId from './resolveId'
 import combineResults from './combineResults'
@@ -204,8 +205,12 @@ async function get(
   )
 
   try {
-    await addNodeMarkers(client, ctx)
-    await refreshMarkers(client, ctx)
+    const nodeMarkers = await addNodeMarkers(client, ctx)
+    const findMarkers = await flushFindMarkers(client, ctx)
+
+    if (nodeMarkers || findMarkers) {
+      await refreshMarkers(client, ctx)
+    }
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
Similarly to how we buffer node markers.

This seems to have a relatively large performance improvement, especially in cases with nested $inherit or $find operations.