### PR TITLE
Single ref with $field in $list fixes

### DIFF
--- a/client/src/get/executeGetOperations/find.ts
+++ b/client/src/get/executeGetOperations/find.ts
@@ -119,7 +119,8 @@ function parseGetOpts(
     }
   > = nestedMapping || {}
 
-  const $fieldOpt = props.$field
+  const $fieldOpt =
+    props.$list && props.$field && pathPrefix === '' ? undefined : props.$field
 
   const addMapping = ($field: string | string[], path: string) => {
     if (!$field) {

--- a/client/src/get/executeGetOperations/find.ts
+++ b/client/src/get/executeGetOperations/find.ts
@@ -1035,10 +1035,9 @@ const executeFindOperation = async (
             }
 
             if (targetField) {
-              // TODO This won't work?
-              // for (const f of targetField) {
-              //  setNestedResult(entryRes, f, casted)
-              // }
+              for (const f of targetField) {
+                setNestedResult(entryRes, f, casted)
+              }
             } else {
               if (isReferences) {
                 setNestedResult(entryRes, path.slice(0, -2), [

--- a/client/src/get/executeGetOperations/find.ts
+++ b/client/src/get/executeGetOperations/find.ts
@@ -119,13 +119,50 @@ function parseGetOpts(
     }
   > = nestedMapping || {}
 
+  const $fieldOpt = props.$field
+
+  const addMapping = ($field: string | string[], path: string) => {
+    if (!$field) {
+      return
+    }
+
+    if (Array.isArray($field)) {
+      fields.get(type).add($field.join('|'))
+      $field.forEach((f) => {
+        if (!mapping[f]) {
+          mapping[f] = { targetField: [path] }
+          return
+        }
+        if (!mapping[f].targetField) {
+          mapping[f].targetField = [path]
+          return
+        }
+        mapping[f].targetField.push(path)
+      })
+    } else {
+      fields.get(type).add($field)
+      if (!mapping[$field]) {
+        mapping[$field] = { targetField: [path] }
+      } else if (!mapping[$field].targetField) {
+        mapping[$field].targetField = [path]
+      } else {
+        mapping[$field].targetField.push(path)
+      }
+    }
+  }
+
+  let hasKeys = false
   for (const k in props) {
     if ((k === '$list' || k === '$find') && pathPrefix === '') {
       // ignore
     } else if (props.$list && k === '$field' && pathPrefix === '') {
       // ignore
     } else if (!k.startsWith('$') && props[k] === true) {
-      fields.get(type).add(pathPrefix + k)
+      if ($fieldOpt) {
+        addMapping($fieldOpt + '.' + k, pathPrefix + k)
+      } else {
+        fields.get(type).add(pathPrefix + k)
+      }
     } else if (props[k] === false) {
       fields.get(type).add(`!${pathPrefix + k}`)
     } else if (k === '$inherit') {
@@ -138,15 +175,8 @@ function parseGetOpts(
       }
 
       let $field = props.$field as string
-      if ($field) {
-        if (!mapping[$field]) {
-          mapping[$field] = { targetField: [path] }
-        } else if (!mapping[$field].targetField) {
-          mapping[$field].targetField = [path]
-        } else {
-          mapping[$field].targetField.push(path)
-        }
-      } else {
+      addMapping($field, path)
+      if (!$field) {
         $field = path
       }
 
@@ -179,30 +209,7 @@ function parseGetOpts(
 
       isInherit = true
     } else if (k === '$field') {
-      const $field = props[k]
-      if (Array.isArray($field)) {
-        fields.get(type).add($field.join('|'))
-        $field.forEach((f) => {
-          if (!mapping[f]) {
-            mapping[f] = { targetField: [path] }
-            return
-          }
-          if (!mapping[f].targetField) {
-            mapping[f].targetField = [path]
-            return
-          }
-          mapping[f].targetField.push(path)
-        })
-      } else {
-        fields.get(type).add($field)
-        if (!mapping[$field]) {
-          mapping[$field] = { targetField: [path] }
-        } else if (!mapping[$field].targetField) {
-          mapping[$field].targetField = [path]
-        } else {
-          mapping[$field].targetField.push(path)
-        }
-      }
+      // no-op
     } else if (k === '$default') {
       fields.get(type).add(path)
       const $default = props[k]
@@ -241,6 +248,11 @@ function parseGetOpts(
     } else if (k.startsWith('$')) {
       return [fields, mapping, true, false]
     } else if (typeof props[k] === 'object') {
+      const nestedProps = Object.assign({}, props[k])
+      if ($fieldOpt) {
+        nestedProps.$field = $fieldOpt + '.' + k
+      }
+
       const [nestedFieldsMap, , hasSpecial, nestedInherit] = parseGetOpts(
         schema,
         props[k],
@@ -263,6 +275,14 @@ function parseGetOpts(
         fields.set(type, set)
       }
     }
+
+    if (k !== '$field') {
+      hasKeys = true
+    }
+  }
+
+  if (!hasKeys) {
+    addMapping($fieldOpt, path)
   }
 
   return [fields, mapping, false, isInherit]

--- a/client/test/reference.ts
+++ b/client/test/reference.ts
@@ -959,3 +959,113 @@ test.serial('simple singular bidirectional reference', async (t) => {
   await client.delete('root')
   await client.destroy()
 })
+
+test.serial(
+  'list of simple singular reference with $field usage',
+  async (t) => {
+    const client = connect({ port }, { loglevel: 'info' })
+
+    // const match1 = await client.set({
+    //   $id: 'maA',
+    //   title: {
+    //     en: 'yesh match'
+    //   }
+    // })
+
+    // const club1 = await client.set({
+    //   $id: 'clA',
+    //   title: {
+    //     en: 'yesh club'
+    //   },
+    //   specialMatch: match1
+    // })
+
+    const club1 = await client.set({
+      $id: 'clA',
+      title: {
+        en: 'yesh club',
+      },
+      specialMatch: {
+        $id: 'maA',
+        title: {
+          en: 'yesh match',
+        },
+      },
+    })
+
+    let result = await client.get({
+      $id: 'root',
+      $language: 'en',
+      children: {
+        id: true,
+        title: true,
+        parents: true,
+        match: {
+          id: { $field: 'specialMatch.id' },
+          title: { $field: 'specialMatch.title' },
+        },
+        $list: {
+          $find: {
+            $filter: [
+              {
+                $field: 'type',
+                $operator: '=',
+                $value: 'club',
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    console.log(JSON.stringify(result, null, 2))
+    t.deepEqual(result, {
+      children: [
+        {
+          id: 'clA',
+          title: 'yesh club',
+          parents: ['root'],
+          match: { id: 'maA', title: 'yesh match' },
+        },
+      ],
+    })
+
+    // result = await client.get({
+    //   $id: 'root',
+    //   $language: 'en',
+    //   children: {
+    //     id: true,
+    //     title: true,
+    //     parents: true,
+    //     match: {
+    //       $field: 'specialMatch',
+    //       id: true,
+    //       title: true,
+    //     },
+    //     $list: {
+    //       $find: {
+    //         $filter: [
+    //           {
+    //             $field: 'type',
+    //             $operator: '=',
+    //             $value: 'club',
+    //           },
+    //         ],
+    //       },
+    //     },
+    //   },
+    // })
+
+    // console.log(JSON.stringify(result, null, 2))
+    // t.deepEqual(result, {
+    //   children: [
+    //     {
+    //       id: 'clA',
+    //       title: 'yesh club',
+    //       parents: ['root'],
+    //       match: { id: 'maA', title: 'yesh match' },
+    //     },
+    //   ],
+    // })
+  }
+)

--- a/client/test/reference.ts
+++ b/client/test/reference.ts
@@ -1030,42 +1030,42 @@ test.serial(
       ],
     })
 
-    // result = await client.get({
-    //   $id: 'root',
-    //   $language: 'en',
-    //   children: {
-    //     id: true,
-    //     title: true,
-    //     parents: true,
-    //     match: {
-    //       $field: 'specialMatch',
-    //       id: true,
-    //       title: true,
-    //     },
-    //     $list: {
-    //       $find: {
-    //         $filter: [
-    //           {
-    //             $field: 'type',
-    //             $operator: '=',
-    //             $value: 'club',
-    //           },
-    //         ],
-    //       },
-    //     },
-    //   },
-    // })
+    result = await client.get({
+      $id: 'root',
+      $language: 'en',
+      children: {
+        id: true,
+        title: true,
+        parents: true,
+        match: {
+          $field: 'specialMatch',
+          id: true,
+          title: true,
+        },
+        $list: {
+          $find: {
+            $filter: [
+              {
+                $field: 'type',
+                $operator: '=',
+                $value: 'club',
+              },
+            ],
+          },
+        },
+      },
+    })
 
-    // console.log(JSON.stringify(result, null, 2))
-    // t.deepEqual(result, {
-    //   children: [
-    //     {
-    //       id: 'clA',
-    //       title: 'yesh club',
-    //       parents: ['root'],
-    //       match: { id: 'maA', title: 'yesh match' },
-    //     },
-    //   ],
-    // })
+    console.log(JSON.stringify(result, null, 2))
+    t.deepEqual(result, {
+      children: [
+        {
+          id: 'clA',
+          title: 'yesh club',
+          parents: ['root'],
+          match: { id: 'maA', title: 'yesh match' },
+        },
+      ],
+    })
   }
 )


### PR DESCRIPTION
Fixes 2 scenarios:
1) using $field that points to a field within a dereferenced single ref within a $list response
```
{
      $id: 'root',
      $language: 'en',
      children: {
        id: true,
        title: true,
        parents: true,
        match: {
          id: { $field: 'specialMatch.id' },
          title: { $field: 'specialMatch.title' },
        },
        $list: {
          $find: {
            $filter: [
              {
                $field: 'type',
                $operator: '=',
                $value: 'club',
              },
            ],
          },
        },
      },
    }
```
2) using $field on a single reference object with keys listed
```
{
      $id: 'root',
      $language: 'en',
      children: {
        id: true,
        title: true,
        parents: true,
        match: {
          $field: 'specialMatch',
          id: true,
          title: true,
        },
        $list: {
          $find: {
            $filter: [
              {
                $field: 'type',
                $operator: '=',
                $value: 'club',
              },
            ],
          },
        },
      },
    }
```